### PR TITLE
fix: stream upload bodies to fix memory leak on large files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "immichsync"
-version = "0.1.6"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2362,6 +2362,7 @@ dependencies = [
  "dirs 5.0.1",
  "eframe",
  "egui",
+ "futures-util",
  "glob",
  "hostname",
  "kamadak-exif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "immichsync"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Windows system tray app that syncs photos/videos to Immich"
 license = "GPL-3.0-only"
@@ -90,8 +90,11 @@ open = "5"
 # Semantic versioning
 semver = "1"
 
-# Streaming I/O utilities (bandwidth throttling)
+# Streaming I/O utilities (bandwidth throttling, file → byte stream for uploads)
 tokio-util = { version = "0.7", features = ["io"] }
+
+# Stream combinators (for throttled upload bodies)
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
 # Temp files in tests
 [dev-dependencies]

--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -1,12 +1,19 @@
 use chrono::{DateTime, Utc};
+use futures_util::StreamExt;
 use reqwest::multipart::{Form, Part};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use std::time::Duration;
 use tokio::fs;
-use tokio::io::AsyncReadExt;
+use tokio_util::io::ReaderStream;
 use tracing::{debug, instrument, warn};
 
 use super::{ApiError, ImmichClient};
+
+/// Chunk size for streaming file uploads. 64 KB balances syscall overhead
+/// against memory residency — at any moment only one chunk is in flight,
+/// so a 4 GB video uses ~64 KB instead of 4 GB.
+const UPLOAD_CHUNK_SIZE: usize = 64 * 1024;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -106,16 +113,39 @@ impl ImmichClient {
         modified_at: DateTime<Utc>,
     ) -> Result<UploadResult, ApiError> {
         let path = file_path.as_ref();
-        debug!("reading file for upload");
 
-        let bytes = if self.bandwidth_limit_bps > 0 {
-            // Throttled read: read in chunks with sleeps to stay under the limit.
-            throttled_read(path, self.bandwidth_limit_bps).await
-                .map_err(|e| ApiError::Unexpected(format!("failed to read file: {e}")))?
+        // Stat the file to get its length for the multipart Content-Length.
+        let metadata = fs::metadata(path)
+            .await
+            .map_err(|e| ApiError::Unexpected(format!("failed to stat file: {e}")))?;
+        let file_size = metadata.len();
+
+        // Open the file and wrap it in a chunked stream. At any moment only
+        // one chunk is held in memory, regardless of file size.
+        let file = fs::File::open(path)
+            .await
+            .map_err(|e| ApiError::Unexpected(format!("failed to open file: {e}")))?;
+        let reader_stream = ReaderStream::with_capacity(file, UPLOAD_CHUNK_SIZE);
+
+        debug!(file_size, "streaming asset upload");
+
+        // Optionally throttle: sleep between chunks proportional to chunk size.
+        // Token-bucket would be more accurate but a per-chunk sleep is
+        // sufficient for the user-facing "limit upload speed" feature.
+        let body = if self.bandwidth_limit_bps > 0 {
+            let bps = self.bandwidth_limit_bps;
+            let throttled = reader_stream.then(move |chunk| async move {
+                if let Ok(ref bytes) = chunk {
+                    let sleep_ms = (bytes.len() as u64 * 1000) / bps;
+                    if sleep_ms > 0 {
+                        tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                    }
+                }
+                chunk
+            });
+            reqwest::Body::wrap_stream(throttled)
         } else {
-            fs::read(path)
-                .await
-                .map_err(|e| ApiError::Unexpected(format!("failed to read file: {e}")))?
+            reqwest::Body::wrap_stream(reader_stream)
         };
 
         // Derive a filename for the multipart part; fall back to "asset" if
@@ -130,7 +160,7 @@ impl ImmichClient {
         // strictly require a correct value.
         let mime = mime_from_extension(path);
 
-        let file_part = Part::bytes(bytes)
+        let file_part = Part::stream_with_length(body, file_size)
             .file_name(filename)
             .mime_str(mime)
             .map_err(|e| ApiError::Unexpected(format!("invalid MIME type: {e}")))?;
@@ -289,39 +319,6 @@ impl crate::upload::worker::AssetUploader for ImmichClient {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Read a file with bandwidth throttling.
-///
-/// Reads in 64 KB chunks, sleeping between chunks to stay under the
-/// specified bytes-per-second limit.
-async fn throttled_read(path: &Path, bytes_per_sec: u64) -> std::io::Result<Vec<u8>> {
-    const CHUNK_SIZE: usize = 64 * 1024; // 64 KB chunks
-
-    let meta = fs::metadata(path).await?;
-    let file_size = meta.len() as usize;
-
-    let mut file = fs::File::open(path).await?;
-    let mut buffer = Vec::with_capacity(file_size);
-    let mut chunk = vec![0u8; CHUNK_SIZE];
-
-    loop {
-        let n = file.read(&mut chunk).await?;
-        if n == 0 {
-            break;
-        }
-        buffer.extend_from_slice(&chunk[..n]);
-
-        // Calculate how long to sleep to stay under the rate limit.
-        if bytes_per_sec > 0 {
-            let sleep_ms = (n as u64 * 1000) / bytes_per_sec;
-            if sleep_ms > 0 {
-                tokio::time::sleep(std::time::Duration::from_millis(sleep_ms)).await;
-            }
-        }
-    }
-
-    Ok(buffer)
-}
 
 /// Return a best-effort MIME type string for a file based on its extension.
 ///


### PR DESCRIPTION
## Summary

`upload_asset` in `src/api/assets.rs` was reading the entire file into a `Vec<u8>` before handing it to `reqwest::multipart::Part::bytes`. For a 4 GB video that meant ~4 GB of RAM allocated up front (plus reqwest's internal copy of the multipart payload). The throttled-read path was even worse: it pre-allocated `Vec::with_capacity(file_size)` and grew it chunk-by-chunk while still buffering the whole file before sending.

This PR replaces the read-then-send pattern with a chunked stream:

- `tokio::fs::File` → `tokio_util::io::ReaderStream::with_capacity(file, 64 KB)`
- Wrapped via `reqwest::Body::wrap_stream` and sent through `Part::stream_with_length(body, file_size)`
- Bandwidth throttling re-implemented as a `StreamExt::then` adapter that sleeps between chunks based on the configured rate, so it throttles the wire send rather than buffering the file twice

Memory residency for an in-flight upload is now bounded at ~64 KB per upload regardless of file size.

## Changes

- `src/api/assets.rs` — stream upload body, drop `throttled_read` helper
- `Cargo.toml` — add `futures-util` (used for `StreamExt::then` on the throttled stream); bump to `0.1.8`

## Test plan

- [x] `cargo check` clean (only pre-existing dead-code warnings)
- [x] `cargo test` — 56 passed, 0 failed
- [ ] Manual: upload a >2 GB video and watch RSS in Task Manager — should stay flat instead of growing with file size
- [ ] Manual: upload with bandwidth limit set to e.g. 1 MB/s and confirm throttling still applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)