### PR TITLE
fix: handle WM_CLOSE so Task Manager 'End task' shuts down cleanly

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -118,6 +118,15 @@ impl App {
     ///
     /// Must be called on the main thread before [`run`].
     pub fn init(&mut self) -> anyhow::Result<()> {
+        // Register the hidden top-level shutdown window before anything else.
+        // Without it, Task Manager → "End task" can't find a window to send
+        // WM_CLOSE to and goes straight to TerminateProcess, leaving
+        // in-flight uploads orphaned. The window must be created on the
+        // same thread that runs the main message pump (this thread).
+        if let Err(e) = crate::platform::shutdown::install() {
+            warn!(error = %e, "Failed to register shutdown window — Task Manager 'End task' may force-kill");
+        }
+
         // Recover any entries stuck in "uploading" state from a previous crash.
         {
             let db = self.db.inner().lock().unwrap();

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -9,6 +9,7 @@ pub mod encryption;
 pub mod install;
 pub mod known_folders;
 pub mod shortcuts;
+pub mod shutdown;
 pub mod single_instance;
 
 /// Application User Model ID for toast notifications and Start Menu shortcuts.

--- a/src/platform/shutdown.rs
+++ b/src/platform/shutdown.rs
@@ -1,0 +1,114 @@
+//! Hidden top-level window that catches Windows shutdown messages.
+//!
+//! Task Manager → "End task" (and `taskkill` without `/F`) sends `WM_CLOSE`
+//! to a process's top-level windows and waits ~5 seconds before escalating
+//! to `TerminateProcess`. A tray-only app has no visible top-level window,
+//! so without this hook Task Manager finds nothing to message and goes
+//! straight to `TerminateProcess` — leaving in-flight uploads orphaned.
+//!
+//! We register a hidden (no `WS_VISIBLE`) top-level window whose WndProc
+//! translates close-related messages into `PostQuitMessage(0)`. The main
+//! thread's existing Win32 message pump in `App::run` then sees `WM_QUIT`
+//! and runs the normal shutdown path.
+//!
+//! Messages handled:
+//! - `WM_CLOSE`           — Task Manager "End task", taskkill (no /F)
+//! - `WM_QUERYENDSESSION` — Logoff/shutdown asking for permission
+//! - `WM_ENDSESSION`      — Logoff/shutdown actually proceeding
+//!
+//! True kill via `TerminateProcess` (Task Manager → "End process tree" or
+//! `taskkill /F`) cannot be caught. The crash-recovery path in
+//! `App::init` resets stale `"uploading"` queue rows back to `"pending"`
+//! on next startup so partial uploads aren't lost — just retried.
+
+use thiserror::Error;
+use tracing::{debug, info};
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::UI::WindowsAndMessaging::{
+    CreateWindowExW, DefWindowProcW, PostQuitMessage, RegisterClassW, WINDOW_EX_STYLE,
+    WINDOW_STYLE, WM_CLOSE, WM_ENDSESSION, WM_QUERYENDSESSION, WNDCLASSW,
+};
+
+#[derive(Debug, Error)]
+pub enum ShutdownWindowError {
+    #[error("CreateWindowExW failed: {0}")]
+    Create(windows::core::Error),
+}
+
+/// Register the shutdown window on the current thread.
+///
+/// Must be called from the same thread that runs the main Win32 message
+/// pump — window messages are dispatched only to the thread that owns the
+/// window. In ImmichSync that's the thread running `App::run`.
+pub fn install() -> Result<(), ShutdownWindowError> {
+    // Null-terminated wide strings kept alive across the FFI calls.
+    let class_wide: Vec<u16> = "ImmichSyncShutdown\0".encode_utf16().collect();
+    let title_wide: Vec<u16> = "ImmichSync\0".encode_utf16().collect();
+
+    let wc = WNDCLASSW {
+        lpfnWndProc: Some(shutdown_wnd_proc),
+        lpszClassName: PCWSTR(class_wide.as_ptr()),
+        ..Default::default()
+    };
+
+    // Re-registering the same class would error; install() is called once
+    // at startup so we ignore the return value.
+    unsafe {
+        RegisterClassW(&wc);
+    }
+
+    let hwnd = unsafe {
+        CreateWindowExW(
+            WINDOW_EX_STYLE::default(),
+            PCWSTR(class_wide.as_ptr()),
+            PCWSTR(title_wide.as_ptr()),
+            // WS_OVERLAPPED with no WS_VISIBLE → top-level, never shown.
+            // The lack of HWND_MESSAGE parent is what makes it top-level
+            // (and therefore enumerable by Task Manager) instead of
+            // message-only like watch::device's WM_DEVICECHANGE window.
+            WINDOW_STYLE::default(),
+            0,
+            0,
+            0,
+            0,
+            None, // no parent — top-level
+            None,
+            None,
+            None,
+        )
+    }
+    .map_err(ShutdownWindowError::Create)?;
+
+    info!(?hwnd, "Shutdown window registered");
+    Ok(())
+}
+
+unsafe extern "system" fn shutdown_wnd_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    match msg {
+        WM_CLOSE => {
+            info!("WM_CLOSE received — initiating graceful shutdown");
+            PostQuitMessage(0);
+            LRESULT(0)
+        }
+        WM_QUERYENDSESSION => {
+            // TRUE = we agree to end. Windows will then deliver WM_ENDSESSION.
+            debug!("WM_QUERYENDSESSION received");
+            LRESULT(1)
+        }
+        WM_ENDSESSION => {
+            // wParam != 0 means the session is actually ending (not cancelled).
+            if wparam.0 != 0 {
+                info!("WM_ENDSESSION received — initiating graceful shutdown");
+                PostQuitMessage(0);
+            }
+            LRESULT(0)
+        }
+        _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+    }
+}

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -165,8 +165,13 @@ impl UploadPipeline {
         self.worker.stop();
 
         if let Some(handle) = self.worker_handle.take() {
-            // Give the worker a moment to finish its current upload.
-            let timeout = std::time::Duration::from_secs(30);
+            // Cap the wait at 3s. Windows Task Manager / WM_CLOSE allows
+            // ~5s before escalating to TerminateProcess; staying under
+            // that lets the process exit cleanly when the user clicks
+            // "End task". In-flight uploads abandoned here will be reset
+            // from "uploading" back to "pending" by reset_stale_uploading
+            // on next startup, so nothing is lost — just retried.
+            let timeout = std::time::Duration::from_secs(3);
             match tokio::time::timeout(timeout, handle).await {
                 Ok(Ok(())) => {
                     info!("Upload worker stopped cleanly");
@@ -176,7 +181,7 @@ impl UploadPipeline {
                 }
                 Err(_) => {
                     tracing::warn!(
-                        "Upload worker did not stop within {:?}; abandoning",
+                        "Upload worker did not stop within {:?}; abandoning (in-flight uploads will resume on next launch)",
                         timeout
                     );
                 }


### PR DESCRIPTION
## Summary

A tray-only app has no visible top-level window, so when the user picks ImmichSync in Task Manager and clicks "End task" Windows finds nothing to send `WM_CLOSE` to and skips straight to `TerminateProcess`. That orphans in-flight uploads and leaves SQLite queue rows stuck in `"uploading"`.

This PR fixes the polite-kill path:

- **`src/platform/shutdown.rs` (new)** — registers a hidden top-level window (no `WS_VISIBLE`) on the main thread. Its WndProc translates `WM_CLOSE`, `WM_QUERYENDSESSION`, and `WM_ENDSESSION` into `PostQuitMessage(0)`, so the existing main-loop shutdown path in `App::run` fires normally.
- **`src/upload/mod.rs`** — reduces `UploadPipeline::stop`'s worker-join timeout from 30s → 3s so the process actually exits inside Windows' ~5s grace window before escalation to `TerminateProcess`. Any upload abandoned at the timeout is safe: `reset_stale_uploading` at next startup reverts it from `"uploading"` → `"pending"` and retries.
- **`src/app.rs`** — calls `platform::shutdown::install()` from `App::init` (must be on the same thread as the message pump).

True kill via `TerminateProcess` (Task Manager → "End process tree", `taskkill /F`, OOM killer, etc.) still can't be caught — the kernel doesn't notify us. That path falls through to the same crash-recovery on next launch, which already worked.

## Why three messages, not just `WM_CLOSE`

- `WM_CLOSE` — Task Manager "End task", `taskkill` (no `/F`)
- `WM_QUERYENDSESSION` — logoff/shutdown asking for permission (return TRUE so Windows agrees and proceeds to WM_ENDSESSION)
- `WM_ENDSESSION` — logoff/shutdown actually proceeding (only act when wParam ≠ 0; FALSE means cancelled)

## Test plan

- [x] `cargo check` clean (only pre-existing dead-code warnings)
- [x] `cargo test` — 56 passed, 0 failed
- [ ] Manual: Task Manager → ImmichSync → "End task" — process exits within ~3s, log shows `WM_CLOSE received`, queue rows are clean on next launch
- [ ] Manual: log off Windows — process exits cleanly, log shows `WM_ENDSESSION received`
- [ ] Manual: Task Manager → "End process tree" (force kill) — process dies immediately, next launch's `reset_stale_uploading` fixes any orphaned `"uploading"` rows

## Notes

- This branches from `development` before #1 (memory leak fix) merges. After #1 merges, this branch should rebase onto the new tip — Cargo.toml will inherit the 0.1.8 bump from #1, no manual version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)