### PR TITLE
fix: open PR instead of pushing direct to satisfy default-branch protection

### DIFF
--- a/.github/workflows/generate-artifacts.yml
+++ b/.github/workflows/generate-artifacts.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: artifacts-${{ github.ref }}
@@ -80,10 +81,26 @@ jobs:
           } > SBOM.md
           rm metadata.json
 
-      - name: Commit artifacts if changed
-        uses: stefanzweifel/git-auto-commit-action@v5
+      # Open a PR instead of pushing directly. The org-level Default Branch
+      # Protection ruleset requires PRs to the default branch, so the previous
+      # git-auto-commit-action push was rejected (GH006). Tracked in issue #14.
+      - name: Open PR with regenerated artifacts
+        uses: peter-evans/create-pull-request@v6
         with:
-          commit_message: "chore: regenerate SBOM and STRUCTURE [skip ci]"
-          file_pattern: "SBOM.md STRUCTURE.md"
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          branch: chore/regenerate-artifacts
+          base: ${{ github.ref_name }}
+          delete-branch: true
+          add-paths: |
+            SBOM.md
+            STRUCTURE.md
+          commit-message: "chore: regenerate SBOM and STRUCTURE"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          title: "chore: regenerate SBOM and STRUCTURE"
+          body: |
+            Auto-generated regeneration of `SBOM.md` and `STRUCTURE.md` from commit ${{ github.sha }}.
+
+            Triggered by: `${{ github.event_name }}` on `${{ github.ref_name }}`.
+          labels: |
+            type:enhancement
+            category:improvement


### PR DESCRIPTION
## What

Swap `stefanzweifel/git-auto-commit-action@v5` for `peter-evans/create-pull-request@v6` in `.github/workflows/generate-artifacts.yml`. The workflow now opens a PR titled `chore: regenerate SBOM and STRUCTURE` against the triggering branch instead of pushing direct.

## Why

The org-level **Default Branch Protection** ruleset (id 15744970, created 2026-04-29) requires all changes to the default branch to come via PR. The previous direct-push step was rejected on every run since 2026-04-26 with:

```
remote: error: GH006: Protected branch update failed for refs/heads/development.
```

This left ``Generate Repo Artifacts`` red on five consecutive runs and would bite every other BR repo as the same workflow rolls out fleet-wide.

## How

- `peter-evans/create-pull-request@v6` opens a PR from a stable feature branch (`chore/regenerate-artifacts`) with `delete-branch: true` to keep the branch list clean
- `add-paths` narrows the diff to exactly `SBOM.md` and `STRUCTURE.md`
- Workflow now requests `pull-requests: write` in addition to `contents: write`
- Auto-merge has been enabled on the repo via `gh repo edit --enable-auto-merge`
- The PR title and commit message keep the same `chore:` prefix; the prior `[skip ci]` is gone because there's no longer a direct push to skip

## Friction left

The org ruleset still requires 1 approving review on default-branch PRs. The existing `OrganizationAdmin` bypass entry with `bypass_mode: pull_request` means **Nate can approve+merge his own PRs in one click**, so each regen needs one click. True zero-touch needs a dedicated GitHub App with bypass ... tracked as a follow-up (option C from issue #14).

## Closes

- #14

## Related

- Workflow rolls out across BR repos per [DevOps book](https://kb.beesroadhouse.com/books/developer-operations-devops); this PR pattern is the right replacement everywhere
- `CLAUDE.md:94` ("development is the default branch, direct pushes allowed") is now stale doc ... will file a separate docs-drift issue