### PR TITLE
fix: harden upload pipeline for large files (#17)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,14 @@
-# Build target directory on local disk to avoid UNC path issues when the
-# repo lives on a mapped network drive.
-[build]
-target-dir = "C:\\Users\\natesmith\\.cargo-target\\immichsync"
+# Cargo build configuration.
+#
+# On checkouts hosted on a mapped network drive (e.g. seadrive), cargo can
+# hit UNC path issues that slow or break builds. If you encounter that,
+# set CARGO_TARGET_DIR in your shell environment to a path on a local
+# drive ... for example:
+#
+#   PowerShell (per session):  $env:CARGO_TARGET_DIR = "$env:LOCALAPPDATA\cargo-target\immichsync"
+#   PowerShell (persistent):   [Environment]::SetEnvironmentVariable("CARGO_TARGET_DIR", "$env:LOCALAPPDATA\cargo-target\immichsync", "User")
+#   bash (per session):        export CARGO_TARGET_DIR="$HOME/.cargo-target/immichsync"
+#
+# CI overrides this via the CARGO_TARGET_DIR env var on every cargo step
+# (see .github/workflows/ci.yml + release.yml), so no repo-level override
+# is needed for the build pipeline.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,6 +9,7 @@ pub use auth::UserInfo;
 pub use server::ServerInfo;
 
 use reqwest::header::{HeaderMap, HeaderValue};
+use std::time::Duration;
 use thiserror::Error;
 
 /// All errors that can arise from Immich API calls.
@@ -79,8 +80,21 @@ impl ImmichClient {
         // default means callers never have to remember to add it.
         default_headers.insert("x-api-key", key_value);
 
+        // Timeouts/keep-alive tuned for streaming uploads of large files (50GB+ videos):
+        // - No overall .timeout() — a 50GB upload at 10MB/s legitimately takes ~83 minutes.
+        // - read_timeout: 120s without any bytes flowing = dead connection, abort fast.
+        // - connect_timeout: 30s to establish TCP+TLS is plenty on any non-pathological link.
+        // - tcp_keepalive: 60s probes keep middleboxes (firewalls, NATs) from idle-closing
+        //   the connection during long uploads. Without this, a quiet TCP stream is silently
+        //   reaped by a firewall and read_timeout takes the full 120s to notice.
+        // - pool_idle_timeout: 120s caps how long an idle connection stays in the pool
+        //   before a fresh one is opened on next use.
         let client = reqwest::Client::builder()
             .default_headers(default_headers)
+            .connect_timeout(Duration::from_secs(30))
+            .read_timeout(Duration::from_secs(120))
+            .tcp_keepalive(Duration::from_secs(60))
+            .pool_idle_timeout(Duration::from_secs(120))
             .build()
             .map_err(ApiError::Network)?;
 

--- a/src/upload/worker.rs
+++ b/src/upload/worker.rs
@@ -346,6 +346,54 @@ async fn process_item(
         }
     };
 
+    // On retry, ask the server whether it already has this asset before
+    // re-uploading. Catches the case where a prior attempt completed
+    // server-side but the connection died before the client got the
+    // response — without this pre-check we'd re-upload the whole file
+    // (potentially 50+ GB) for nothing. Skipped on the first attempt
+    // because the local DB dedup table already covers that path.
+    if entry.retry_count > 0 {
+        if let Some(checksum) = entry.file_hash.as_deref() {
+            let check = uploader
+                .check_duplicates(vec![BulkCheckItem {
+                    id: device_asset_id.clone(),
+                    checksum: checksum.to_string(),
+                }])
+                .await;
+            match check {
+                Ok(results) => {
+                    if let Some(r) = results.first() {
+                        if r.exists {
+                            info!(
+                                id = entry.id,
+                                attempt = entry.retry_count,
+                                asset_id = ?r.asset_id,
+                                "Pre-check: server already has this asset, skipping re-upload"
+                            );
+                            if let Err(e) = store.mark_completed(entry.id, r.asset_id.as_deref()) {
+                                error!(
+                                    id = entry.id,
+                                    error = %e,
+                                    "Failed to mark entry completed after server-side pre-check"
+                                );
+                            }
+                            return;
+                        }
+                    }
+                }
+                Err(e) => {
+                    // Pre-check is best-effort — if it fails, fall through and
+                    // attempt the upload normally.
+                    warn!(
+                        id = entry.id,
+                        error = %e,
+                        "Pre-check before retry failed; proceeding with full upload"
+                    );
+                }
+            }
+        }
+    }
+
     // Attempt the upload.
     let result = uploader
         .upload_asset(


### PR DESCRIPTION
## Summary

Two-commit fix for issue #17 — 50GB+ video uploads failing on transient network events.

- **`src/api/mod.rs`** — adds per-connection timeouts + TCP keep-alive to the shared reqwest client (no overall `.timeout()` so legitimate hours-long uploads aren't artificially bounded).
- **`src/upload/worker.rs`** — on retry attempts, pre-checks the server via `bulk-upload-check` before re-uploading. Catches the "server got the file, connection died before client got the 201 response" case so we don't re-burn 50GB the server already has.
- **`.cargo/config.toml`** — chore: removed the machine-specific target-dir override (CI already overrides via env var; repo-level path broke other devs' machines with different usernames).

## What this does NOT fix

**Resume-from-byte-offset.** Immich's server API has no chunked/resumable upload primitive — verified against the OpenAPI spec on `main` and the last several releases. Feature is requested upstream since 2022 but not shipped as of v2.7.5 (April 2026). Retries still restart from byte 0. For chronically flaky networks on 50GB files, this is fundamentally a hard problem until upstream Immich ships their chunked API. Issue #17 has the full research.

The fixes here cover the **happy-ish path**: a 50GB upload that hits one transient blip near the end now has a chance of completing (server already received the bytes, pre-check confirms, we skip re-upload). A 50GB upload that hits a blip 20% in still costs the full 50GB on retry — but at least the retry isn't blocked by a silently-dead TCP connection that the old code would sit on forever.

## Closes

- #17

## Test plan

- [x] `cargo check` clean (69 pre-existing warnings, none new — tracked in #9)
- [x] Smoke test: small file upload still works (any photo)
- [x] Manual: large file upload with simulated mid-stream connection drop, observe pre-check skip on retry
- [x] CI build green

## Notes for reviewer

The `read_timeout` (120s) value is the load-bearing tunable. Too short = false positives on slow networks. Too long = takes a while to abort dead connections. 120s tolerates most legitimate slow-network situations and aborts dead TCP in a reasonable window. Open to feedback if a different value is better for your network conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)