### PR TITLE
refactor: correct CLAUDE.md branch-protection claims (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,12 +91,19 @@ cargo test
 
 Follows the DevOps book standards: [Branching Strategy](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy), [Change Taxonomy](https://kb.beesroadhouse.com/books/developer-operations-devops/page/change-taxonomy), [PR Merge Strategy](https://kb.beesroadhouse.com/books/developer-operations-devops/page/pr-merge-strategy), [Issue Workflow](https://kb.beesroadhouse.com/books/developer-operations-devops/page/issue-workflow).
 
-- `development` is the default branch (always shippable, direct pushes allowed)
-- `release` is the only protected branch (org ruleset)
-- Work branches: `feature/`, `improvement/`, `refactor/`, `bug/`
-- One discrete change per PR; rebase onto `development` before merge
-- **Squash-and-merge** for work-branch → `development`. **Merge commit** for `development` → `release` (squashing the release transition breaks ancestor relationship)
-- `BREAKING:` prefix in PR title forces a major version bump regardless of type
+- `development` is the default branch (always shippable). All changes land via PR — the org `Default Branch Protection` ruleset (id 15744970) requires 1 approving review + thread resolution and rejects direct pushes with `GH013`.
+- `release` is also PR-protected by the org `Release Branch Protection` ruleset (id 15553415), which targets `refs/heads/release`, `refs/heads/release/*`, and `refs/heads/release-*`.
+- Work branches: `feature/`, `improvement/`, `refactor/`, `bug/`.
+- One discrete change per PR; rebase onto `development` before merge.
+- **Squash-and-merge** for work-branch → `development`. **Merge commit** for `development` → `release` (squashing the release transition breaks ancestor relationship).
+- `BREAKING:` prefix in PR title forces a major version bump regardless of type.
+- Standard PR-create incantation (auto-merge once review + required checks pass):
+  ```bash
+  gh pr create --base development --head <branch> --title "..." --body "..."
+  gh pr merge --auto --squash --delete-branch
+  ```
+  Use `--admin --squash --delete-branch` instead for the documented "small touchups" OrganizationAdmin bypass (docs typos, link fixes, version-bump-only PRs). See [Branching Strategy](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) for the full policy.
+- Required status checks on this repo (per repo-level ruleset id 16845497): `Build & test` (ci.yml) AND `Regenerate SBOM and STRUCTURE` (generate-artifacts.yml).
 
 ### Two-Tier Labels
 

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-25 20:16 UTC from commit `90b7ad4` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-25 20:33 UTC from commit `3a49423` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-25 20:16 UTC from commit `90b7ad4`._
+_Auto-generated on 2026-05-25 20:33 UTC from commit `3a49423`._
 
 ```
 .


### PR DESCRIPTION
## Summary

`CLAUDE.md:94-95` claimed direct pushes to `development` were allowed and that `release` was the only protected branch. That was accurate at the time of PR #10 (2026-04-25) but became stale 4 days later when the org-level `Default Branch Protection` ruleset (id 15744970) went active. The drift is what masked issue #14 for four weeks — the workflow was doing exactly what the doc said was allowed.

## What changed

Rewrites the Git Workflow bullet list to:
- Reference both org rulesets (15744970 + 15553415) by id with correct enforcement description
- Document the standard auto-merge PR-create incantation
- Note the OrganizationAdmin `--admin` bypass for small touchups
- List the repo-level required status checks (ruleset 16845497) so contributors know what gates apply

Matches the [Branching Strategy](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) doc update from earlier today.

## Closes

- #19

## Test plan

- [x] Doc-only change, no code paths touched
- [x] CI build & test green
- [x] Artifact regen workflow runs cleanly (this is also a real-world test of PR #22's new workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)