### PR TITLE
fix: reconcile WatchEngine with DB folder set every 2s (#16)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -39,6 +39,11 @@ pub struct App {
     runtime: Arc<tokio::runtime::Runtime>,
     last_stats_update: Instant,
     last_trash_cleanup: Instant,
+    /// Last time we reconciled the WatchEngine's watched-folder set against the DB.
+    /// The Settings subprocess mutates the DB independently of the running engine,
+    /// so we periodically diff and converge to fix the "Remove without Save still
+    /// uploads files" footgun.
+    last_folder_reconcile: Instant,
     paused: bool,
     /// Track previous syncing state to detect transitions for notifications.
     was_syncing: bool,
@@ -102,6 +107,7 @@ impl App {
             runtime,
             last_stats_update: Instant::now(),
             last_trash_cleanup: Instant::now(),
+            last_folder_reconcile: Instant::now(),
             paused: false,
             was_syncing: false,
             notifications,
@@ -269,6 +275,14 @@ impl App {
 
             // Periodically refresh tray with queue statistics.
             self.update_tray_stats();
+
+            // Periodically reconcile the WatchEngine's view of watched folders
+            // against the DB. The Settings subprocess mutates the DB without
+            // notifying the main process until it exits — until reconcile fires,
+            // a folder removed via Settings would still be watched (and its files
+            // uploaded). Cheap when there's no drift; restarts the engine when
+            // there is.
+            self.reconcile_watch_folders();
 
             // Periodic trash cleanup (hourly).
             if self.last_trash_cleanup.elapsed() >= Duration::from_secs(3600) {
@@ -552,6 +566,79 @@ impl App {
                     self.was_syncing = is_syncing;
                 }
             }
+        }
+    }
+
+    /// Reconcile the WatchEngine's view of watched folders against the DB.
+    ///
+    /// Background: the Settings window is a separate subprocess. It writes
+    /// directly to the DB on `Remove Folder` / `Add Folder` clicks, but the
+    /// main process only gets a config-update message when the subprocess
+    /// exits. Between those two events, the engine watches a folder the
+    /// user has already removed — files added there still upload. Issue #16.
+    ///
+    /// Fix: every `FOLDER_RECONCILE_INTERVAL`, compare the engine's watched
+    /// set against the DB's enabled-folder set. If they differ, restart the
+    /// engine to converge. Restart also re-spawns the watch→pipeline bridge
+    /// with a refreshed folder map, so per-event folder-id lookup stays
+    /// correct after additions.
+    fn reconcile_watch_folders(&mut self) {
+        const FOLDER_RECONCILE_INTERVAL: Duration = Duration::from_secs(2);
+
+        if self.last_folder_reconcile.elapsed() < FOLDER_RECONCILE_INTERVAL {
+            return;
+        }
+        self.last_folder_reconcile = Instant::now();
+
+        // What the DB says should be watched.
+        let db_paths: std::collections::HashSet<std::path::PathBuf> = {
+            let db = match self.db.inner().lock() {
+                Ok(g) => g,
+                Err(_) => {
+                    warn!("Folder reconcile: DB mutex poisoned, skipping");
+                    return;
+                }
+            };
+            match db.get_folders() {
+                Ok(folders) => folders
+                    .into_iter()
+                    .filter(|f| f.enabled)
+                    .map(|f| {
+                        let p = std::path::PathBuf::from(&f.path);
+                        std::fs::canonicalize(&p).unwrap_or(p)
+                    })
+                    .collect(),
+                Err(e) => {
+                    warn!(error = %e, "Folder reconcile: get_folders failed, skipping");
+                    return;
+                }
+            }
+        };
+
+        // What the engine actually watches.
+        let engine_paths = match self.watch_engine.as_ref() {
+            Some(e) => e.watched_paths(),
+            None => std::collections::HashSet::new(),
+        };
+
+        if db_paths == engine_paths {
+            return;
+        }
+
+        let removed: Vec<_> = engine_paths.difference(&db_paths).cloned().collect();
+        let added: Vec<_> = db_paths.difference(&engine_paths).cloned().collect();
+        info!(
+            removed = removed.len(),
+            added = added.len(),
+            "Folder reconcile: drift detected, restarting watch engine to converge"
+        );
+
+        if let Some(ref mut engine) = self.watch_engine {
+            engine.stop_all();
+        }
+        self.watch_engine = None;
+        if let Err(e) = self.start_watch_engine() {
+            warn!(error = %e, "Folder reconcile: restart_watch_engine failed");
         }
     }
 

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -203,6 +203,16 @@ impl WatchEngine {
         self.watchers.len()
     }
 
+    /// Return the set of canonicalized paths currently being watched.
+    ///
+    /// Used by the reconcile pass that compares the engine's view of watched
+    /// folders against the DB's view, to detect drift introduced by the
+    /// Settings subprocess mutating the DB without the main process getting
+    /// a config-update message until the subprocess exits.
+    pub fn watched_paths(&self) -> std::collections::HashSet<PathBuf> {
+        self.watchers.keys().cloned().collect()
+    }
+
     /// Return `true` if the given path is currently being watched.
     pub fn is_watching(&self, path: &Path) -> bool {
         if self.watchers.contains_key(path) {


### PR DESCRIPTION
## Summary

Closes #16 — folders removed in the Settings window no longer keep uploading until the user clicks Save.

## Root cause

The Settings window is a separate **subprocess** (spawned via `std::process::Command` in `spawn_window_subprocess`). It mutates the DB directly on Remove/Add clicks, but the main process only receives a `Config` message via the mpsc channel after the subprocess exits. Between the Remove click and the window close, the running `WatchEngine` in the main process is unaware — it keeps watching the folder, enqueues new files, uploads them.

## Fix

Periodic reconcile pass in the main app loop:

1. Every `FOLDER_RECONCILE_INTERVAL` (2s), read the DB's enabled-folder set.
2. Compare to `WatchEngine::watched_paths()`.
3. If they differ, `stop_all()` + `start_watch_engine()` to converge.

The reconcile is **cheap when there's no drift** — one DB query + a `HashSet` equality check. The expensive restart only fires on actual drift.

## Why restart-on-drift rather than incremental add/remove

The watch→pipeline bridge task holds an `Arc<HashMap<PathBuf, i64>>` (path → folder_id) that's built at engine-start time. To support incremental `engine.add_folder()` calls from reconcile, that map would need to be a `Mutex` or `RwLock`-wrapped shared structure and mutated atomically with the engine's watcher set. Restart sidesteps the synchronization entirely: the new engine spawns a fresh bridge task with a refreshed map. Restart cost is sub-second, only fires on actual user action.

## Side effects covered

- **Add Folder without Save**: same architecture issue, now also handled symmetrically by the reconcile diff.
- **Disable Folder checkbox without Save**: enabled-filter means disabled folders show up as "removed" in the reconcile diff → engine stops watching them.

## What it does NOT do

The reconcile fires every 2s, so there's still a small window (up to 2s) between the Settings click and the engine convergence. Files added in that window would be enqueued. The proper fix for zero-latency convergence is an IPC channel between the Settings subprocess and the main process (named pipe / file watcher / etc.) — out of scope here; 2s is good enough to close issue #16 in practice.

## Test plan

- [x] `cargo check` clean (69 pre-existing warnings, none new — tracked in #9)
- [x] CI build & test green
- [x] Manual repro of #16's reproduction steps — file added 3s after Remove should NOT upload
- [x] Manual: Add a folder via Settings, drop a file in it before Save, file should upload within ~2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)