### PR TITLE
refactor: cargo fmt sweep + enable fmt as gating CI check (#8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
         env:
           CARGO_TARGET_DIR: target
 
-      - name: Format check (informational)
-        # Not gating yet — see issue tracker for a planned `cargo fmt` sweep.
-        continue-on-error: true
+      - name: Format check
+        # Gating after the v0.2.0 cargo fmt sweep (issue #8).
+        # Run `cargo fmt --all` locally before opening a PR; CI fails otherwise.
         run: cargo fmt --all -- --check
 
       # Skip artifact upload on PRs targeting release (development → release).

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-25 20:55 UTC from commit `175e02b` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-25 20:57 UTC from commit `acde73b` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-25 20:55 UTC from commit `175e02b`._
+_Auto-generated on 2026-05-25 20:57 UTC from commit `acde73b`._
 
 ```
 .

--- a/src/api/albums.rs
+++ b/src/api/albums.rs
@@ -112,12 +112,7 @@ impl ImmichClient {
         let body = AddAssetsRequest { ids: asset_ids };
         let url = self.url(&format!("/api/albums/{album_id}/assets"));
 
-        let response = self
-            .client
-            .put(&url)
-            .json(&body)
-            .send()
-            .await?;
+        let response = self.client.put(&url).json(&body).send().await?;
 
         if !response.status().is_success() {
             return Err(Self::map_status_error(response).await);
@@ -150,11 +145,7 @@ impl ImmichClient {
     pub async fn get_albums(&self) -> Result<Vec<Album>, ApiError> {
         debug!("fetching album list");
 
-        let response = self
-            .client
-            .get(self.url("/api/albums"))
-            .send()
-            .await?;
+        let response = self.client.get(self.url("/api/albums")).send().await?;
 
         if !response.status().is_success() {
             return Err(Self::map_status_error(response).await);

--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -261,7 +261,13 @@ impl crate::upload::worker::AssetUploader for ImmichClient {
         modified_at: DateTime<Utc>,
     ) -> anyhow::Result<crate::upload::worker::UploadResult> {
         let result = self
-            .upload_asset(file_path, device_asset_id, device_id, created_at, modified_at)
+            .upload_asset(
+                file_path,
+                device_asset_id,
+                device_id,
+                created_at,
+                modified_at,
+            )
             .await?;
 
         Ok(crate::upload::worker::UploadResult {
@@ -270,11 +276,7 @@ impl crate::upload::worker::AssetUploader for ImmichClient {
         })
     }
 
-    async fn add_asset_to_album(
-        &self,
-        album_name: &str,
-        asset_id: &str,
-    ) -> anyhow::Result<()> {
+    async fn add_asset_to_album(&self, album_name: &str, asset_id: &str) -> anyhow::Result<()> {
         // Get or create album by name.
         let albums = self.get_albums().await?;
         let album_id = if let Some(album) = albums.iter().find(|a| a.album_name == album_name) {
@@ -284,7 +286,8 @@ impl crate::upload::worker::AssetUploader for ImmichClient {
             album.id
         };
 
-        self.add_assets_to_album(&album_id, vec![asset_id.to_string()]).await?;
+        self.add_assets_to_album(&album_id, vec![asset_id.to_string()])
+            .await?;
         Ok(())
     }
 
@@ -341,8 +344,9 @@ fn mime_from_extension(path: &Path) -> &'static str {
         "tiff" | "tif" => "image/tiff",
         "bmp" => "image/bmp",
         // RAW formats — treated as octet-stream; Immich handles them server-side.
-        "raw" | "cr2" | "cr3" | "nef" | "arw" | "dng" | "orf" | "rw2" | "pef" | "srw"
-        | "raf" => "application/octet-stream",
+        "raw" | "cr2" | "cr3" | "nef" | "arw" | "dng" | "orf" | "rw2" | "pef" | "srw" | "raf" => {
+            "application/octet-stream"
+        }
         "mp4" | "m4v" => "video/mp4",
         "mov" => "video/quicktime",
         "avi" => "video/x-msvideo",

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -47,11 +47,7 @@ impl ImmichClient {
     pub async fn validate_api_key(&self) -> Result<UserInfo, ApiError> {
         debug!("validating API key via /api/users/me");
 
-        let response = self
-            .client
-            .get(self.url("/api/users/me"))
-            .send()
-            .await?;
+        let response = self.client.get(self.url("/api/users/me")).send().await?;
 
         if !response.status().is_success() {
             return Err(Self::map_status_error(response).await);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -115,9 +115,7 @@ impl ImmichClient {
 
     /// Map an HTTP status code to the appropriate `ApiError` variant, using the
     /// response body (if readable) as the detail message.
-    pub(crate) async fn map_status_error(
-        response: reqwest::Response,
-    ) -> ApiError {
+    pub(crate) async fn map_status_error(response: reqwest::Response) -> ApiError {
         let status = response.status();
         let body = response
             .text()

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -41,11 +41,7 @@ impl ImmichClient {
     pub async fn ping(&self) -> Result<bool, ApiError> {
         debug!("pinging Immich server");
 
-        let response = self
-            .client
-            .get(self.url("/api/server/ping"))
-            .send()
-            .await?;
+        let response = self.client.get(self.url("/api/server/ping")).send().await?;
 
         if !response.status().is_success() {
             return Err(Self::map_status_error(response).await);

--- a/src/app.rs
+++ b/src/app.rs
@@ -150,8 +150,8 @@ impl App {
         }
 
         // Create system tray (must be on main thread).
-        let (tray, tray_rx) = TrayApp::new()
-            .map_err(|e| anyhow::anyhow!("Failed to create tray: {}", e))?;
+        let (tray, tray_rx) =
+            TrayApp::new().map_err(|e| anyhow::anyhow!("Failed to create tray: {}", e))?;
         self.tray = Some(tray);
         self.tray_rx = Some(tray_rx);
 
@@ -159,12 +159,8 @@ impl App {
         if let Some(ref client) = self.client {
             let uploader: Arc<dyn AssetUploader> = Arc::new(client.clone());
             let store: Arc<dyn QueueStore> = self.db.clone();
-            let mut pipeline = UploadPipeline::new(
-                store,
-                &self.config.server,
-                &self.config.upload,
-                uploader,
-            );
+            let mut pipeline =
+                UploadPipeline::new(store, &self.config.server, &self.config.upload, uploader);
 
             // Pipeline spawns tokio tasks — enter the runtime context.
             let _guard = self.runtime.enter();
@@ -187,9 +183,7 @@ impl App {
         } else {
             info!("No server configured; pipeline not started");
             if let Some(ref mut tray) = self.tray {
-                tray.update_state(TrayState::Error(
-                    "Server not configured".to_string(),
-                ));
+                tray.update_state(TrayState::Error("Server not configured".to_string()));
             }
         }
 
@@ -324,23 +318,22 @@ impl App {
             if folders.is_empty() {
                 drop(db);
                 // First run: add the user's Pictures folder as a default.
-                if let Ok(pictures) =
-                    crate::platform::known_folders::get_pictures_folder()
-                {
+                if let Ok(pictures) = crate::platform::known_folders::get_pictures_folder() {
                     if pictures.exists() {
                         info!(path = %pictures.display(), "Adding default Pictures folder");
                         let db = self.db.inner().lock().unwrap();
-                        if let Ok(id) = db.add_folder(
-                            &pictures.display().to_string(),
-                            Some("Pictures"),
-                            true,
-                        ) {
+                        if let Ok(id) =
+                            db.add_folder(&pictures.display().to_string(), Some("Pictures"), true)
+                        {
                             let filter = FileFilter::new();
                             let canon = std::fs::canonicalize(&pictures)
                                 .unwrap_or_else(|_| pictures.clone());
-                            if let Err(e) =
-                                engine.add_folder(pictures, filter, false, self.runtime.handle().clone())
-                            {
+                            if let Err(e) = engine.add_folder(
+                                pictures,
+                                filter,
+                                false,
+                                self.runtime.handle().clone(),
+                            ) {
                                 warn!("Failed to add Pictures watcher: {}", e);
                             } else {
                                 path_to_folder_id.insert(canon, id);
@@ -358,12 +351,11 @@ impl App {
                         warn!(path = %folder.path, "Watch folder missing, skipping");
                         continue;
                     }
-                    let is_network =
-                        folder.watch_mode == crate::db::WatchMode::Poll;
+                    let is_network = folder.watch_mode == crate::db::WatchMode::Poll;
                     let filter = FileFilter::new();
-                    let canon = std::fs::canonicalize(&path)
-                        .unwrap_or_else(|_| path.clone());
-                    if let Err(e) = engine.add_folder(path, filter, is_network, self.runtime.handle().clone())
+                    let canon = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                    if let Err(e) =
+                        engine.add_folder(path, filter, is_network, self.runtime.handle().clone())
                     {
                         warn!(path = %folder.path, error = %e, "Failed to add watcher");
                     } else {
@@ -382,7 +374,10 @@ impl App {
             let concurrency = self.config.upload.concurrency as usize;
             let folder_map = Arc::new(path_to_folder_id);
 
-            info!("Spawning watch→pipeline bridge task (concurrency={})", concurrency);
+            info!(
+                "Spawning watch→pipeline bridge task (concurrency={})",
+                concurrency
+            );
             let bridge_store = store.clone();
             let bridge_map = folder_map.clone();
             self.runtime.spawn(async move {
@@ -561,7 +556,8 @@ impl App {
 
                     // Detect Syncing → Idle transition for notification.
                     if self.was_syncing && !is_syncing && stats.completed > 0 {
-                        self.notifications.notify_upload_complete(stats.completed as u32);
+                        self.notifications
+                            .notify_upload_complete(stats.completed as u32);
                     }
                     self.was_syncing = is_syncing;
                 }
@@ -691,8 +687,12 @@ impl App {
                 let info_clone = info.clone();
                 self.runtime.spawn_blocking(move || {
                     match updater::download_and_apply(&info_clone) {
-                        Ok(()) => { let _ = tx.send(Ok(info_clone.new_version)); }
-                        Err(e) => { let _ = tx.send(Err(e.to_string())); }
+                        Ok(()) => {
+                            let _ = tx.send(Ok(info_clone.new_version));
+                        }
+                        Err(e) => {
+                            let _ = tx.send(Err(e.to_string()));
+                        }
                     }
                 });
 
@@ -709,7 +709,11 @@ impl App {
 
     /// Poll the background download channel for completion.
     fn poll_update_download(&mut self) {
-        let result = match self.update_download_rx.as_ref().and_then(|rx| rx.try_recv().ok()) {
+        let result = match self
+            .update_download_rx
+            .as_ref()
+            .and_then(|rx| rx.try_recv().ok())
+        {
             Some(r) => r,
             None => return,
         };
@@ -739,7 +743,8 @@ impl App {
                     }
                 }
 
-                self.notifications.notify_error(&format!("Update download failed: {e}"));
+                self.notifications
+                    .notify_error(&format!("Update download failed: {e}"));
             }
         }
     }
@@ -954,13 +959,7 @@ async fn initial_scan(
 
     match result {
         Ok((scanned, enqueued, skipped, errors)) => {
-            info!(
-                scanned,
-                enqueued,
-                skipped,
-                errors,
-                "Initial scan: complete"
-            );
+            info!(scanned, enqueued, skipped, errors, "Initial scan: complete");
         }
         Err(e) => {
             warn!(error = %e, "Initial scan task panicked");

--- a/src/config.rs
+++ b/src/config.rs
@@ -287,11 +287,10 @@ impl Config {
             source,
         })?;
 
-        let mut config: Self =
-            toml::from_str(&contents).map_err(|source| ConfigError::Parse {
-                path: path.clone(),
-                source,
-            })?;
+        let mut config: Self = toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+            path: path.clone(),
+            source,
+        })?;
 
         // Decrypt API key if it was stored encrypted.
         if crate::platform::encryption::is_encrypted(&config.server.api_key) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -403,9 +403,7 @@ impl Database {
             )
             .optional()?;
 
-        Ok(version
-            .and_then(|v| v.parse::<u32>().ok())
-            .unwrap_or(0))
+        Ok(version.and_then(|v| v.parse::<u32>().ok()).unwrap_or(0))
     }
 
     fn set_schema_version(&self, version: u32) -> Result<(), DbError> {
@@ -462,10 +460,8 @@ impl Database {
 
     /// Remove a watched folder by id.
     pub fn remove_folder(&self, id: i64) -> Result<(), DbError> {
-        self.conn.execute(
-            "DELETE FROM watched_folders WHERE id = ?1",
-            params![id],
-        )?;
+        self.conn
+            .execute("DELETE FROM watched_folders WHERE id = ?1", params![id])?;
         Ok(())
     }
 
@@ -709,7 +705,13 @@ impl Database {
                  completed_at = ?4,
                  retry_count = retry_count + ?5
              WHERE id = ?1",
-            params![id, status.as_str(), error_msg, completed_at, retry_increment],
+            params![
+                id,
+                status.as_str(),
+                error_msg,
+                completed_at,
+                retry_increment
+            ],
         )?;
         Ok(())
     }
@@ -889,7 +891,10 @@ impl crate::upload::queue::QueueStore for DbStore {
         Ok(id)
     }
 
-    fn dequeue_pending(&self, limit: usize) -> anyhow::Result<Vec<crate::upload::queue::QueueEntry>> {
+    fn dequeue_pending(
+        &self,
+        limit: usize,
+    ) -> anyhow::Result<Vec<crate::upload::queue::QueueEntry>> {
         let db = self.db.lock().unwrap();
         let entries = db.dequeue_pending(limit as i64)?;
         Ok(entries
@@ -915,23 +920,14 @@ impl crate::upload::queue::QueueStore for DbStore {
             .collect())
     }
 
-    fn update_status(
-        &self,
-        id: i64,
-        status: &str,
-        error: Option<&str>,
-    ) -> anyhow::Result<()> {
+    fn update_status(&self, id: i64, status: &str, error: Option<&str>) -> anyhow::Result<()> {
         let db = self.db.lock().unwrap();
         let qs = QueueStatus::from_str(status);
         db.update_queue_status(id, &qs, error)?;
         Ok(())
     }
 
-    fn mark_completed(
-        &self,
-        id: i64,
-        _asset_id: Option<&str>,
-    ) -> anyhow::Result<()> {
+    fn mark_completed(&self, id: i64, _asset_id: Option<&str>) -> anyhow::Result<()> {
         let db = self.db.lock().unwrap();
         db.update_queue_status(id, &QueueStatus::Completed, None)?;
         Ok(())
@@ -1020,7 +1016,9 @@ mod tests {
     #[test]
     fn add_and_get_folder() {
         let db = open_test_db();
-        let id = db.add_folder("/some/path", Some("My Photos"), false).unwrap();
+        let id = db
+            .add_folder("/some/path", Some("My Photos"), false)
+            .unwrap();
         assert!(id > 0);
 
         let folders = db.get_folders().unwrap();
@@ -1128,9 +1126,7 @@ mod tests {
     #[test]
     fn update_queue_status_to_completed() {
         let db = open_test_db();
-        let id = db
-            .enqueue("/photos/c.jpg", None, None, None)
-            .unwrap();
+        let id = db.enqueue("/photos/c.jpg", None, None, None).unwrap();
 
         db.update_queue_status(id, &QueueStatus::Uploading, None)
             .unwrap();
@@ -1189,8 +1185,10 @@ mod tests {
         let id2 = db.enqueue("/photos/h.jpg", None, None, None).unwrap();
 
         // Simulate a crash: mark both as uploading.
-        db.update_queue_status(id1, &QueueStatus::Uploading, None).unwrap();
-        db.update_queue_status(id2, &QueueStatus::Uploading, None).unwrap();
+        db.update_queue_status(id1, &QueueStatus::Uploading, None)
+            .unwrap();
+        db.update_queue_status(id2, &QueueStatus::Uploading, None)
+            .unwrap();
 
         let stats = db.get_queue_stats().unwrap();
         assert_eq!(stats.uploading, 2);
@@ -1211,8 +1209,10 @@ mod tests {
         let id = db.enqueue("/photos/retry.jpg", None, None, None).unwrap();
 
         // Simulate: dequeued and failed, then set back to pending for retry.
-        db.update_queue_status(id, &QueueStatus::Uploading, None).unwrap();
-        db.update_queue_status(id, &QueueStatus::Pending, Some("timeout")).unwrap();
+        db.update_queue_status(id, &QueueStatus::Uploading, None)
+            .unwrap();
+        db.update_queue_status(id, &QueueStatus::Pending, Some("timeout"))
+            .unwrap();
 
         // Check that retry_count was incremented.
         let entries = db.get_recent_queue_entries(10).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,9 @@ fn debug_log(msg: &str) {
         .append(true)
         .open(&path)
     {
-        let _ = writeln!(f, "[{}] [pid={}] {msg}",
+        let _ = writeln!(
+            f,
+            "[{}] [pid={}] {msg}",
             chrono::Local::now().format("%H:%M:%S%.3f"),
             std::process::id(),
         );
@@ -33,8 +35,11 @@ fn debug_log(msg: &str) {
 }
 
 fn main() -> anyhow::Result<()> {
-    debug_log(&format!("=== ImmichSync starting === version={} args={:?}",
-        env!("CARGO_PKG_VERSION"), std::env::args().collect::<Vec<_>>()));
+    debug_log(&format!(
+        "=== ImmichSync starting === version={} args={:?}",
+        env!("CARGO_PKG_VERSION"),
+        std::env::args().collect::<Vec<_>>()
+    ));
 
     // ── Legacy data migration ────────────────────────────────────────────
     // Move config/db/logs from old %APPDATA%\ImmichSync\ to the new
@@ -53,8 +58,7 @@ fn main() -> anyhow::Result<()> {
     let log_dir = data_dir.join("logs");
     std::fs::create_dir_all(&log_dir)?;
 
-    let file_appender =
-        tracing_appender::rolling::daily(&log_dir, "immichsync.log");
+    let file_appender = tracing_appender::rolling::daily(&log_dir, "immichsync.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
     tracing_subscriber::fmt()
@@ -86,7 +90,10 @@ fn main() -> anyhow::Result<()> {
     // We call AllowSetForegroundWindow before spawning so the subprocess
     // can bring its window to the foreground on Windows.
     let current_exe_path = std::env::current_exe().unwrap_or_default();
-    debug_log(&format!("Install check: current_exe={}", current_exe_path.display()));
+    debug_log(&format!(
+        "Install check: current_exe={}",
+        current_exe_path.display()
+    ));
     match platform::is_running_installed() {
         Ok(false) => {
             debug_log("is_running_installed=false");
@@ -101,26 +108,39 @@ fn main() -> anyhow::Result<()> {
             } else {
                 let installed_exe = platform::installed_exe_path().ok();
                 let installed_exists = installed_exe.as_ref().map_or(false, |p| p.exists());
-                debug_log(&format!("installed_exe={:?}, exists={installed_exists}", installed_exe));
+                debug_log(&format!(
+                    "installed_exe={:?}, exists={installed_exists}",
+                    installed_exe
+                ));
 
                 if installed_exists {
                     // Determine if the installed copy needs updating.
                     let installed_ver = platform::install::installed_version();
                     let update_info = match &installed_ver {
-                        None => {
-                            Some((String::from("unknown"), platform::install::running_version().to_string()))
-                        }
+                        None => Some((
+                            String::from("unknown"),
+                            platform::install::running_version().to_string(),
+                        )),
                         Some(_) => platform::install::is_update_available(),
                     };
-                    debug_log(&format!("installed_ver={installed_ver:?}, update_info={update_info:?}"));
+                    debug_log(&format!(
+                        "installed_ver={installed_ver:?}, update_info={update_info:?}"
+                    ));
 
                     if let Some((old_ver, new_ver)) = update_info {
                         info!(
                             from = %old_ver, to = %new_ver,
                             "Newer version running, spawning install-update dialog"
                         );
-                        debug_log(&format!("Spawning install-update dialog: {old_ver} -> {new_ver}"));
-                        match spawn_install_dialog(&["--window", "install-update", "--old-version", &old_ver]) {
+                        debug_log(&format!(
+                            "Spawning install-update dialog: {old_ver} -> {new_ver}"
+                        ));
+                        match spawn_install_dialog(&[
+                            "--window",
+                            "install-update",
+                            "--old-version",
+                            &old_ver,
+                        ]) {
                             Some(0) => {
                                 // The subprocess already relaunched from the installed path
                                 // and killed the old instance + parent. Just exit.
@@ -129,7 +149,9 @@ fn main() -> anyhow::Result<()> {
                                 return Ok(());
                             }
                             other => {
-                                debug_log(&format!("Install dialog returned {other:?}, continuing"));
+                                debug_log(&format!(
+                                    "Install dialog returned {other:?}, continuing"
+                                ));
                                 info!("User declined update, continuing from current location");
                             }
                         }
@@ -154,7 +176,9 @@ fn main() -> anyhow::Result<()> {
                             return Ok(());
                         }
                         other => {
-                            debug_log(&format!("Install dialog returned {other:?}, continuing portable"));
+                            debug_log(&format!(
+                                "Install dialog returned {other:?}, continuing portable"
+                            ));
                             info!("User chose portable mode, continuing from current location");
                         }
                     }
@@ -199,7 +223,13 @@ fn main() -> anyhow::Result<()> {
     if config.server.url.is_empty() {
         info!("Server not configured, launching first-run wizard");
         let exe = platform::installed_exe_path()
-            .map(|p| if p.exists() { p } else { std::env::current_exe().unwrap_or(p) })
+            .map(|p| {
+                if p.exists() {
+                    p
+                } else {
+                    std::env::current_exe().unwrap_or(p)
+                }
+            })
             .unwrap_or_else(|_| std::env::current_exe().expect("current_exe"));
         let status = std::process::Command::new(&exe)
             .args(["--window", "wizard"])
@@ -228,9 +258,7 @@ fn main() -> anyhow::Result<()> {
     let db_store = Arc::new(db::DbStore::new(database));
 
     // ── Immich client ────────────────────────────────────────────────────
-    let client = if !config.server.url.is_empty()
-        && !config.server.api_key.is_empty()
-    {
+    let client = if !config.server.url.is_empty() && !config.server.api_key.is_empty() {
         match api::ImmichClient::with_bandwidth_limit(
             &config.server.url,
             &config.server.api_key,
@@ -387,13 +415,18 @@ fn spawn_install_dialog(args: &[&str]) -> Option<i32> {
     }
 
     let exe = std::env::current_exe().expect("current_exe");
-    debug_log(&format!("spawn_install_dialog: exe={}, args={args:?}", exe.display()));
+    debug_log(&format!(
+        "spawn_install_dialog: exe={}, args={args:?}",
+        exe.display()
+    ));
     info!(exe = %exe.display(), args = ?args, "Spawning install dialog subprocess");
 
     match std::process::Command::new(&exe).args(args).status() {
         Ok(status) => {
             let code = status.code();
-            debug_log(&format!("spawn_install_dialog: subprocess exited with code={code:?}"));
+            debug_log(&format!(
+                "spawn_install_dialog: subprocess exited with code={code:?}"
+            ));
             info!(code = ?code, "Install dialog subprocess exited");
             code
         }

--- a/src/platform/autostart.rs
+++ b/src/platform/autostart.rs
@@ -13,8 +13,8 @@
 use thiserror::Error;
 use windows::core::PCWSTR;
 use windows::Win32::System::Registry::{
-    RegCloseKey, RegDeleteValueW, RegOpenKeyExW, RegQueryValueExW, RegSetValueExW,
-    HKEY_CURRENT_USER, HKEY, KEY_READ, KEY_WRITE, REG_SZ,
+    RegCloseKey, RegDeleteValueW, RegOpenKeyExW, RegQueryValueExW, RegSetValueExW, HKEY,
+    HKEY_CURRENT_USER, KEY_READ, KEY_WRITE, REG_SZ,
 };
 
 const RUN_KEY: &str = "Software\\Microsoft\\Windows\\CurrentVersion\\Run\0";
@@ -83,8 +83,8 @@ pub fn is_autostart_enabled() -> Result<bool, AutostartError> {
     let _ = unsafe { RegCloseKey(hkey) };
 
     match query_result.0 {
-        0 => Ok(true),                  // ERROR_SUCCESS — value exists
-        2 => Ok(false),                 // ERROR_FILE_NOT_FOUND — value absent
+        0 => Ok(true),  // ERROR_SUCCESS — value exists
+        2 => Ok(false), // ERROR_FILE_NOT_FOUND — value absent
         e => Err(AutostartError::RegistryQuery(e as u32)),
     }
 }
@@ -115,8 +115,9 @@ pub fn set_autostart(enabled: bool) -> Result<(), AutostartError> {
     let result = if enabled {
         // Always point autostart at the installed exe path so the registry
         // value is stable regardless of where the app was originally launched.
-        let exe = crate::platform::install::installed_exe_path()
-            .map_err(|e| AutostartError::ExePath(std::io::Error::new(std::io::ErrorKind::Other, e)))?;
+        let exe = crate::platform::install::installed_exe_path().map_err(|e| {
+            AutostartError::ExePath(std::io::Error::new(std::io::ErrorKind::Other, e))
+        })?;
         let exe_str = exe.to_str().ok_or(AutostartError::ExePathEncoding)?;
 
         // Encode as a null-terminated wide string for REG_SZ.
@@ -146,13 +147,11 @@ pub fn set_autostart(enabled: bool) -> Result<(), AutostartError> {
     } else {
         tracing::info!("disabling autostart");
 
-        let r = unsafe {
-            RegDeleteValueW(hkey, PCWSTR(value_wide.as_ptr()))
-        };
+        let r = unsafe { RegDeleteValueW(hkey, PCWSTR(value_wide.as_ptr())) };
 
         match r.0 {
-            0 => Ok(()),    // ERROR_SUCCESS
-            2 => Ok(()),    // ERROR_FILE_NOT_FOUND — already absent, that's fine
+            0 => Ok(()), // ERROR_SUCCESS
+            2 => Ok(()), // ERROR_FILE_NOT_FOUND — already absent, that's fine
             e => Err(AutostartError::RegistryDelete(e as u32)),
         }
     };

--- a/src/platform/drives.rs
+++ b/src/platform/drives.rs
@@ -8,9 +8,7 @@
 
 use std::path::PathBuf;
 use windows::core::PCWSTR;
-use windows::Win32::Storage::FileSystem::{
-    GetDriveTypeW, GetLogicalDrives, GetVolumeInformationW,
-};
+use windows::Win32::Storage::FileSystem::{GetDriveTypeW, GetLogicalDrives, GetVolumeInformationW};
 
 /// High-level drive type, mapped from Win32 DRIVE_* constants.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,9 +34,7 @@ pub struct DriveInfo {
 /// Encode a null-terminated ASCII/UTF-16 drive-root string, e.g. `"C:\\\0"`.
 fn drive_root_wide(letter: char) -> Vec<u16> {
     let s = format!("{}:\\", letter);
-    s.encode_utf16()
-        .chain(std::iter::once(0u16))
-        .collect()
+    s.encode_utf16().chain(std::iter::once(0u16)).collect()
 }
 
 /// Enumerate all logical drives currently visible to the OS.
@@ -67,10 +63,10 @@ pub fn list_drives() -> Vec<DriveInfo> {
         // Determine drive type.
         let raw_type = unsafe { GetDriveTypeW(root_pcwstr) };
         let drive_type = match raw_type {
-            3 => DriveType::Fixed,      // DRIVE_FIXED
-            2 => DriveType::Removable,  // DRIVE_REMOVABLE
-            4 => DriveType::Network,    // DRIVE_REMOTE
-            5 => DriveType::CdRom,      // DRIVE_CDROM
+            3 => DriveType::Fixed,     // DRIVE_FIXED
+            2 => DriveType::Removable, // DRIVE_REMOVABLE
+            4 => DriveType::Network,   // DRIVE_REMOTE
+            5 => DriveType::CdRom,     // DRIVE_CDROM
             _ => DriveType::Unknown,
         };
 
@@ -81,10 +77,10 @@ pub fn list_drives() -> Vec<DriveInfo> {
             GetVolumeInformationW(
                 root_pcwstr,
                 Some(label_buf.as_mut_slice()),
-                None,       // volume serial number
-                None,       // max component length
-                None,       // filesystem flags
-                None,       // filesystem name
+                None, // volume serial number
+                None, // max component length
+                None, // filesystem flags
+                None, // filesystem name
             )
             .is_ok()
         };
@@ -104,12 +100,7 @@ pub fn list_drives() -> Vec<DriveInfo> {
             None
         };
 
-        tracing::debug!(
-            "drive {}: type={:?} label={:?}",
-            letter,
-            drive_type,
-            label
-        );
+        tracing::debug!("drive {}: type={:?} label={:?}", letter, drive_type, label);
 
         drives.push(DriveInfo {
             letter,

--- a/src/platform/encryption.rs
+++ b/src/platform/encryption.rs
@@ -109,9 +109,11 @@ pub fn decrypt_api_key(encrypted: &str) -> Result<String, EncryptionError> {
     }
 
     // Read DPAPI blob length.
-    let dpapi_len =
-        u32::from_le_bytes(payload[0..4].try_into().map_err(|_| EncryptionError::Malformed)?)
-            as usize;
+    let dpapi_len = u32::from_le_bytes(
+        payload[0..4]
+            .try_into()
+            .map_err(|_| EncryptionError::Malformed)?,
+    ) as usize;
 
     if payload.len() < 4 + dpapi_len {
         return Err(EncryptionError::Malformed);
@@ -152,11 +154,11 @@ fn dpapi_protect(data: &[u8]) -> Result<Vec<u8>, EncryptionError> {
     unsafe {
         CryptProtectData(
             &mut input_blob,
-            None,            // description
-            None,            // optional entropy
-            None,            // reserved
-            None,            // prompt struct
-            0,               // flags
+            None, // description
+            None, // optional entropy
+            None, // reserved
+            None, // prompt struct
+            0,    // flags
             &mut output_blob,
         )
         .map_err(|_| EncryptionError::DpapiProtect)?;
@@ -185,11 +187,11 @@ fn dpapi_unprotect(data: &[u8]) -> Result<Vec<u8>, EncryptionError> {
     unsafe {
         CryptUnprotectData(
             &mut input_blob,
-            None,            // description out
-            None,            // optional entropy
-            None,            // reserved
-            None,            // prompt struct
-            0,               // flags
+            None, // description out
+            None, // optional entropy
+            None, // reserved
+            None, // prompt struct
+            0,    // flags
             &mut output_blob,
         )
         .map_err(|_| EncryptionError::DpapiUnprotect)?;

--- a/src/platform/install.rs
+++ b/src/platform/install.rs
@@ -21,10 +21,16 @@ pub enum InstallError {
     CurrentExe(std::io::Error),
 
     #[error("failed to copy exe to `{dest}`: {source}")]
-    Copy { dest: PathBuf, source: std::io::Error },
+    Copy {
+        dest: PathBuf,
+        source: std::io::Error,
+    },
 
     #[error("failed to create directory `{path}`: {source}")]
-    CreateDir { path: PathBuf, source: std::io::Error },
+    CreateDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -103,10 +109,8 @@ fn version_file_path() -> Result<PathBuf, InstallError> {
 /// Write the current binary's version to `version.txt` in the install dir.
 fn write_version_file() -> Result<(), InstallError> {
     let path = version_file_path()?;
-    std::fs::write(&path, running_version()).map_err(|source| InstallError::Copy {
-        dest: path,
-        source,
-    })?;
+    std::fs::write(&path, running_version())
+        .map_err(|source| InstallError::Copy { dest: path, source })?;
     Ok(())
 }
 

--- a/src/platform/known_folders.rs
+++ b/src/platform/known_folders.rs
@@ -43,7 +43,9 @@ pub fn get_pictures_folder() -> Result<PathBuf, KnownFolderError> {
     // Convert the PWSTR to a Rust PathBuf before freeing.
     let path = unsafe {
         // PWSTR::to_string() walks the null-terminated wide string.
-        let s = path_ptr.to_string().map_err(|_| KnownFolderError::InvalidPath)?;
+        let s = path_ptr
+            .to_string()
+            .map_err(|_| KnownFolderError::InvalidPath)?;
         PathBuf::from(s)
     };
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -25,7 +25,10 @@ pub const APP_USER_MODEL_ID: &str = "BeesRoadhouse.ImmichSync";
 pub use autostart::{is_autostart_enabled, set_autostart, AutostartError};
 pub use drives::{has_dcim_folder, list_drives, DriveInfo, DriveType};
 pub use encryption::{decrypt_api_key, encrypt_api_key, is_encrypted, EncryptionError};
-pub use install::{install_exe, installed_exe_path, is_running_installed, migrate_legacy_data, relaunch_installed, running_version};
+pub use install::{
+    install_exe, installed_exe_path, is_running_installed, migrate_legacy_data, relaunch_installed,
+    running_version,
+};
 pub use known_folders::{get_pictures_folder, KnownFolderError};
 pub use shortcuts::{create_desktop_shortcut, create_start_menu_shortcut, ShortcutError};
 pub use single_instance::{SingleInstance, SingleInstanceError};

--- a/src/platform/shortcuts.rs
+++ b/src/platform/shortcuts.rs
@@ -21,7 +21,7 @@ use windows::Win32::System::Com::{
 };
 use windows::Win32::UI::Shell::PropertiesSystem::{IPropertyStore, PROPERTYKEY};
 use windows::Win32::UI::Shell::{
-    IShellLinkW, SHGetKnownFolderPath, FOLDERID_Desktop, FOLDERID_Programs, KNOWN_FOLDER_FLAG,
+    FOLDERID_Desktop, FOLDERID_Programs, IShellLinkW, SHGetKnownFolderPath, KNOWN_FOLDER_FLAG,
 };
 
 // CLSID_ShellLink: {00021401-0000-0000-C000-000000000046}
@@ -148,9 +148,7 @@ fn create_shortcut(
         }
 
         // Set AppUserModelID so toast notifications can find us.
-        let prop_store: IPropertyStore = shell_link
-            .cast()
-            .map_err(ShortcutError::SetAppId)?;
+        let prop_store: IPropertyStore = shell_link.cast().map_err(ShortcutError::SetAppId)?;
 
         let aumid = PROPVARIANT::from(super::APP_USER_MODEL_ID);
         prop_store
@@ -159,9 +157,8 @@ fn create_shortcut(
         prop_store.Commit().map_err(ShortcutError::SetAppId)?;
 
         // Save the .lnk file via IPersistFile.
-        let persist_file: IPersistFile = shell_link
-            .cast()
-            .map_err(ShortcutError::QueryPersistFile)?;
+        let persist_file: IPersistFile =
+            shell_link.cast().map_err(ShortcutError::QueryPersistFile)?;
 
         let lnk_wide: Vec<u16> = lnk_path
             .as_os_str()

--- a/src/platform/single_instance.rs
+++ b/src/platform/single_instance.rs
@@ -47,8 +47,8 @@ impl SingleInstance {
         // for the duration of the call.
         let handle = unsafe {
             CreateMutexW(
-                None,  // default security attributes
-                true,  // we request initial ownership
+                None, // default security attributes
+                true, // we request initial ownership
                 PCWSTR(name_wide.as_ptr()),
             )
         };

--- a/src/ui/first_run.rs
+++ b/src/ui/first_run.rs
@@ -119,14 +119,12 @@ impl eframe::App for WizardAppWrapper {
 
 impl WizardApp {
     fn update_wizard(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show(ctx, |ui| {
-            match self.step {
-                WizardStep::Welcome => self.show_welcome(ui, ctx),
-                WizardStep::ServerConfig => self.show_server_config(ui, ctx),
-                WizardStep::FolderSetup => self.show_folder_setup(ui, ctx),
-                WizardStep::Autostart => self.show_autostart(ui, ctx),
-                WizardStep::Done => self.show_done(ui, ctx),
-            }
+        egui::CentralPanel::default().show(ctx, |ui| match self.step {
+            WizardStep::Welcome => self.show_welcome(ui, ctx),
+            WizardStep::ServerConfig => self.show_server_config(ui, ctx),
+            WizardStep::FolderSetup => self.show_folder_setup(ui, ctx),
+            WizardStep::Autostart => self.show_autostart(ui, ctx),
+            WizardStep::Done => self.show_done(ui, ctx),
         });
     }
 
@@ -196,8 +194,7 @@ impl WizardApp {
             if ui.button("Back").clicked() {
                 self.step = WizardStep::Welcome;
             }
-            let can_proceed =
-                !self.server_url.is_empty() && !self.api_key.is_empty();
+            let can_proceed = !self.server_url.is_empty() && !self.api_key.is_empty();
             ui.add_enabled_ui(can_proceed, |ui| {
                 if ui.button("Next").clicked() {
                     self.config.server.url = self.server_url.clone();
@@ -300,9 +297,7 @@ impl WizardApp {
                 // Add the watch folder to the database.
                 if !self.watch_folder.is_empty() {
                     if let Ok(db) = crate::db::Database::open() {
-                        if let Err(e) =
-                            db.add_folder(&self.watch_folder, None, false)
-                        {
+                        if let Err(e) = db.add_folder(&self.watch_folder, None, false) {
                             tracing::warn!(error = %e, "Failed to add wizard folder");
                         }
                     }
@@ -331,8 +326,7 @@ impl WizardApp {
                             self.test_status = "Connected!".to_string();
                         }
                         Ok(false) => {
-                            self.test_status =
-                                "Server responded but not ready".to_string();
+                            self.test_status = "Server responded but not ready".to_string();
                         }
                         Err(e) => {
                             self.test_status = format!("Failed: {e}");

--- a/src/ui/install.rs
+++ b/src/ui/install.rs
@@ -64,11 +64,7 @@ pub fn run_install_dialog_subprocess(is_update: bool, old_version: Option<String
     };
 
     info!("Opening install dialog (is_update={is_update})");
-    match eframe::run_native(
-        title,
-        options,
-        Box::new(|_cc| Ok(Box::new(app))),
-    ) {
+    match eframe::run_native(title, options, Box::new(|_cc| Ok(Box::new(app)))) {
         Ok(()) => {}
         Err(e) => {
             tracing::error!(error = %e, "eframe::run_native failed for install dialog");
@@ -275,7 +271,8 @@ fn kill_running_instances() {
 /// This works because Windows allows renaming a running exe (just not overwriting).
 fn install_exe_rename_dance() -> Result<(), String> {
     let current = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let dest = crate::platform::installed_exe_path().map_err(|e| format!("installed_exe_path: {e}"))?;
+    let dest =
+        crate::platform::installed_exe_path().map_err(|e| format!("installed_exe_path: {e}"))?;
     let old = dest.with_extension("exe.old");
 
     // Remove leftover .old if it exists.

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -180,13 +180,11 @@ impl eframe::App for SettingsApp {
         });
 
         // Tab content.
-        egui::CentralPanel::default().show(ctx, |ui| {
-            match self.active_tab {
-                Tab::Connection => self.show_connection_tab(ui),
-                Tab::WatchFolders => self.show_watch_folders_tab(ui),
-                Tab::Upload => self.show_upload_tab(ui),
-                Tab::Advanced => self.show_advanced_tab(ui),
-            }
+        egui::CentralPanel::default().show(ctx, |ui| match self.active_tab {
+            Tab::Connection => self.show_connection_tab(ui),
+            Tab::WatchFolders => self.show_watch_folders_tab(ui),
+            Tab::Upload => self.show_upload_tab(ui),
+            Tab::Advanced => self.show_advanced_tab(ui),
         });
 
         // Process deferred folder removal (avoid borrow conflict).
@@ -286,11 +284,7 @@ impl SettingsApp {
                                 .width(120.0)
                                 .selected_text(&selected)
                                 .show_ui(ui, |ui| {
-                                    ui.selectable_value(
-                                        &mut selected,
-                                        "none".to_string(),
-                                        "None",
-                                    );
+                                    ui.selectable_value(&mut selected, "none".to_string(), "None");
                                     ui.selectable_value(
                                         &mut selected,
                                         "folder".to_string(),
@@ -317,10 +311,7 @@ impl SettingsApp {
                             if folder.album_mode == AlbumMode::Fixed {
                                 let name = folder.album_name.get_or_insert_with(String::new);
                                 ui.label("Name:");
-                                ui.add_sized(
-                                    [120.0, 18.0],
-                                    egui::TextEdit::singleline(name),
-                                );
+                                ui.add_sized([120.0, 18.0], egui::TextEdit::singleline(name));
                             }
                         });
 
@@ -443,11 +434,7 @@ impl SettingsApp {
                     .selected_text(&self.log_level)
                     .show_ui(ui, |ui| {
                         for level in &["trace", "debug", "info", "warn", "error"] {
-                            ui.selectable_value(
-                                &mut self.log_level,
-                                level.to_string(),
-                                *level,
-                            );
+                            ui.selectable_value(&mut self.log_level, level.to_string(), *level);
                         }
                     });
                 ui.end_row();
@@ -466,7 +453,10 @@ impl SettingsApp {
         ui.checkbox(&mut self.autostart, "Start with Windows");
         ui.checkbox(&mut self.minimize_to_tray, "Minimize to system tray");
         ui.checkbox(&mut self.show_notifications, "Show notifications");
-        ui.checkbox(&mut self.check_for_updates, "Automatically check for updates");
+        ui.checkbox(
+            &mut self.check_for_updates,
+            "Automatically check for updates",
+        );
         ui.add_enabled_ui(self.check_for_updates, |ui| {
             ui.indent("update_indent", |ui| {
                 ui.horizontal(|ui| {
@@ -510,8 +500,7 @@ impl SettingsApp {
                             self.test_status = "Connected!".to_string();
                         }
                         Ok(false) => {
-                            self.test_status =
-                                "Server responded but not ready".to_string();
+                            self.test_status = "Server responded but not ready".to_string();
                         }
                         Err(e) => {
                             self.test_status = format!("Failed: {e}");
@@ -646,7 +635,12 @@ impl SettingsApp {
                 }
 
                 // Apply trash/delete to already-uploaded files if the user checked the box.
-                if self.apply_existing.get(&folder.id).copied().unwrap_or(false) {
+                if self
+                    .apply_existing
+                    .get(&folder.id)
+                    .copied()
+                    .unwrap_or(false)
+                {
                     self.apply_post_upload_to_existing(&db, folder);
                 }
             }

--- a/src/ui/tray.rs
+++ b/src/ui/tray.rs
@@ -224,9 +224,12 @@ impl TrayApp {
         let view_log_item = MenuItem::with_id(ID_VIEW_LOG, "View Upload Log", true, None);
         let view_trash_item = MenuItem::with_id(ID_VIEW_TRASH, "View Trash", true, None);
         let about_item = MenuItem::with_id(ID_ABOUT, "About ImmichSync", true, None);
-        let check_updates_item = MenuItem::with_id(ID_CHECK_UPDATES, "Check for Updates", true, None);
-        let update_available_item = MenuItem::with_id(ID_UPDATE_AVAILABLE, "Update Available!", false, None);
-        let restart_to_update_item = MenuItem::with_id(ID_RESTART_TO_UPDATE, "Restart to Update", false, None);
+        let check_updates_item =
+            MenuItem::with_id(ID_CHECK_UPDATES, "Check for Updates", true, None);
+        let update_available_item =
+            MenuItem::with_id(ID_UPDATE_AVAILABLE, "Update Available!", false, None);
+        let restart_to_update_item =
+            MenuItem::with_id(ID_RESTART_TO_UPDATE, "Restart to Update", false, None);
         let quit_item = MenuItem::with_id(ID_QUIT, "Quit", true, None);
 
         // ---- Assemble context menu ----
@@ -398,7 +401,8 @@ impl TrayApp {
     pub fn set_update_available(&mut self, version: Option<&str>) {
         match version {
             Some(v) => {
-                self.update_available_item.set_text(&format!("Update Available (v{v})!"));
+                self.update_available_item
+                    .set_text(&format!("Update Available (v{v})!"));
                 self.update_available_item.set_enabled(true);
             }
             None => {
@@ -415,7 +419,8 @@ impl TrayApp {
     pub fn set_restart_to_update(&mut self, version: Option<&str>) {
         match version {
             Some(v) => {
-                self.restart_to_update_item.set_text(&format!("Restart to Update (v{v})"));
+                self.restart_to_update_item
+                    .set_text(&format!("Restart to Update (v{v})"));
                 self.restart_to_update_item.set_enabled(true);
                 // Hide the "Update Available" item since the download is done.
                 self.update_available_item.set_text("Update Available!");

--- a/src/ui/update.rs
+++ b/src/ui/update.rs
@@ -88,13 +88,11 @@ impl eframe::App for UpdateApp {
             self.check_download_state();
         }
 
-        egui::CentralPanel::default().show(ctx, |ui| {
-            match self.state {
-                DialogState::Prompt => self.show_prompt(ui, ctx),
-                DialogState::Downloading => self.show_downloading(ui, ctx),
-                DialogState::ReadyToRestart => self.show_ready(ui, ctx),
-                DialogState::Error => self.show_error(ui, ctx),
-            }
+        egui::CentralPanel::default().show(ctx, |ui| match self.state {
+            DialogState::Prompt => self.show_prompt(ui, ctx),
+            DialogState::Downloading => self.show_downloading(ui, ctx),
+            DialogState::ReadyToRestart => self.show_ready(ui, ctx),
+            DialogState::Error => self.show_error(ui, ctx),
         });
     }
 }
@@ -111,7 +109,10 @@ impl UpdateApp {
             "A new version of ImmichSync is available: v{}",
             self.info.new_version
         ));
-        ui.label(format!("You are currently running v{}", self.info.current_version));
+        ui.label(format!(
+            "You are currently running v{}",
+            self.info.current_version
+        ));
 
         if self.info.size > 0 {
             ui.add_space(4.0);
@@ -271,7 +272,8 @@ impl UpdateApp {
         } else if downloaded == u64::MAX - 1 && total == 0 {
             self.state = DialogState::Error;
             if self.error_msg.is_empty() {
-                self.error_msg = "Download or installation failed. Check logs for details.".to_string();
+                self.error_msg =
+                    "Download or installation failed. Check logs for details.".to_string();
             }
         }
     }

--- a/src/ui/upload_log.rs
+++ b/src/ui/upload_log.rs
@@ -156,7 +156,9 @@ fn load_entries(db: &Arc<DbStore>) -> Vec<LogEntry> {
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_else(|| e.file_path.clone());
 
-            let timestamp = e.completed_at.as_deref()
+            let timestamp = e
+                .completed_at
+                .as_deref()
                 .or(Some(e.queued_at.as_str()))
                 .unwrap_or("")
                 .to_string();

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -118,7 +118,10 @@ async fn check_inner(repo: &str) -> Result<UpdateCheckResult, UpdateError> {
         .await?;
 
     // Parse version from tag (strip leading 'v' if present).
-    let tag = release.tag_name.strip_prefix('v').unwrap_or(&release.tag_name);
+    let tag = release
+        .tag_name
+        .strip_prefix('v')
+        .unwrap_or(&release.tag_name);
     let remote_ver = semver::Version::parse(tag)
         .map_err(|_| UpdateError::InvalidVersion(release.tag_name.clone()))?;
 
@@ -162,10 +165,7 @@ async fn check_inner(repo: &str) -> Result<UpdateCheckResult, UpdateError> {
 ///
 /// `progress_fn` is called with `(bytes_downloaded, total_bytes)`.
 /// Returns the path to the downloaded file.
-pub fn download_update_blocking<F>(
-    url: &str,
-    progress_fn: F,
-) -> Result<PathBuf, UpdateError>
+pub fn download_update_blocking<F>(url: &str, progress_fn: F) -> Result<PathBuf, UpdateError>
 where
     F: Fn(u64, u64),
 {
@@ -178,8 +178,12 @@ where
         .build()
         .map_err(UpdateError::Network)?;
 
-    let mut response = client.get(url).send().map_err(UpdateError::Network)?
-        .error_for_status().map_err(UpdateError::Network)?;
+    let mut response = client
+        .get(url)
+        .send()
+        .map_err(UpdateError::Network)?
+        .error_for_status()
+        .map_err(UpdateError::Network)?;
 
     let total = response.content_length().unwrap_or(0);
 
@@ -237,7 +241,8 @@ pub fn apply_update(new_exe_path: &std::path::Path, new_version: &str) -> Result
     std::fs::rename(new_exe_path, &current_exe).map_err(UpdateError::File)?;
 
     // Step 3: Write version.txt next to the exe.
-    let version_file = current_exe.parent()
+    let version_file = current_exe
+        .parent()
         .map(|p| p.join("version.txt"))
         .unwrap_or_else(|| PathBuf::from("version.txt"));
     let _ = std::fs::write(&version_file, new_version);

--- a/src/upload/hasher.rs
+++ b/src/upload/hasher.rs
@@ -32,11 +32,10 @@ pub enum HasherError {
 pub fn hash_file(path: &Path) -> Result<String, HasherError> {
     let path_str = path.display().to_string();
 
-    let mut file =
-        std::fs::File::open(path).map_err(|source| HasherError::Open {
-            path: path_str.clone(),
-            source,
-        })?;
+    let mut file = std::fs::File::open(path).map_err(|source| HasherError::Open {
+        path: path_str.clone(),
+        source,
+    })?;
 
     let mut hasher = Sha1::new();
     let mut buf = [0u8; 8192];

--- a/src/upload/metadata.rs
+++ b/src/upload/metadata.rs
@@ -66,21 +66,19 @@ pub fn extract_metadata(path: &Path) -> Result<FileMetadata, MetadataError> {
     }
 
     // Fall back to filesystem timestamps.
-    let fs_meta =
-        fs::metadata(path).map_err(|source| MetadataError::FsMetadata {
-            path: path.display().to_string(),
-            source,
-        })?;
+    let fs_meta = fs::metadata(path).map_err(|source| MetadataError::FsMetadata {
+        path: path.display().to_string(),
+        source,
+    })?;
 
-    let modified_at = system_time_to_utc(fs_meta.modified().ok())
-        .ok_or_else(|| MetadataError::NoTimestamp {
+    let modified_at =
+        system_time_to_utc(fs_meta.modified().ok()).ok_or_else(|| MetadataError::NoTimestamp {
             path: path.display().to_string(),
         })?;
 
     // `created()` is not available on all platforms (e.g. some Linux
     // filesystems), so fall back to `modified` when it's absent.
-    let created_at = system_time_to_utc(fs_meta.created().ok())
-        .unwrap_or(modified_at);
+    let created_at = system_time_to_utc(fs_meta.created().ok()).unwrap_or(modified_at);
 
     debug!(
         path = %path.display(),
@@ -104,9 +102,7 @@ fn try_exif_datetime(path: &Path) -> Option<DateTime<Utc>> {
     let file = fs::File::open(path).ok()?;
     let mut reader = BufReader::new(&file);
 
-    let exif = ExifReader::new()
-        .read_from_container(&mut reader)
-        .ok()?;
+    let exif = ExifReader::new().read_from_container(&mut reader).ok()?;
 
     // Prefer DateTimeOriginal (when shutter was pressed) over DateTime
     // (which may reflect when the file was last edited).
@@ -141,33 +137,29 @@ fn parse_exif_datetime(s: &str) -> Option<DateTime<Utc>> {
         })
         .collect();
 
-    let naive =
-        NaiveDateTime::parse_from_str(&normalised, "%Y-%m-%d %H:%M:%S")
-            .map_err(|e| {
-                warn!(
-                    raw = s,
-                    normalised = %normalised,
-                    error = %e,
-                    "Failed to parse EXIF datetime"
-                );
-            })
-            .ok()?;
+    let naive = NaiveDateTime::parse_from_str(&normalised, "%Y-%m-%d %H:%M:%S")
+        .map_err(|e| {
+            warn!(
+                raw = s,
+                normalised = %normalised,
+                error = %e,
+                "Failed to parse EXIF datetime"
+            );
+        })
+        .ok()?;
 
     Some(DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc))
 }
 
 /// Read just the filesystem `mtime` for a path.
 fn fs_modified(path: &Path) -> Result<DateTime<Utc>, MetadataError> {
-    let meta =
-        fs::metadata(path).map_err(|source| MetadataError::FsMetadata {
-            path: path.display().to_string(),
-            source,
-        })?;
+    let meta = fs::metadata(path).map_err(|source| MetadataError::FsMetadata {
+        path: path.display().to_string(),
+        source,
+    })?;
 
-    system_time_to_utc(meta.modified().ok()).ok_or_else(|| {
-        MetadataError::NoTimestamp {
-            path: path.display().to_string(),
-        }
+    system_time_to_utc(meta.modified().ok()).ok_or_else(|| MetadataError::NoTimestamp {
+        path: path.display().to_string(),
     })
 }
 
@@ -177,11 +169,8 @@ fn system_time_to_utc(t: Option<SystemTime>) -> Option<DateTime<Utc>> {
         st.duration_since(SystemTime::UNIX_EPOCH).ok().map(|d| {
             // `chrono::DateTime::from_timestamp` is the non-deprecated form
             // for chrono >= 0.4.27 and returns Option<DateTime<Utc>>.
-            chrono::DateTime::from_timestamp(
-                d.as_secs() as i64,
-                d.subsec_nanos(),
-            )
-            .unwrap_or_else(Utc::now)
+            chrono::DateTime::from_timestamp(d.as_secs() as i64, d.subsec_nanos())
+                .unwrap_or_else(Utc::now)
         })
     })
 }
@@ -201,8 +190,7 @@ mod tests {
         tmp.flush().unwrap();
         let meta = extract_metadata(tmp.path()).unwrap();
         // Both timestamps should be reasonable (after year 2000).
-        let epoch_2000 =
-            chrono::DateTime::from_timestamp(946_684_800, 0).unwrap();
+        let epoch_2000 = chrono::DateTime::from_timestamp(946_684_800, 0).unwrap();
         assert!(meta.created_at > epoch_2000);
         assert!(meta.modified_at > epoch_2000);
     }
@@ -216,7 +204,10 @@ mod tests {
     #[test]
     fn parse_exif_datetime_valid() {
         let dt = parse_exif_datetime("2023:06:15 14:30:00").unwrap();
-        assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2023-06-15 14:30:00");
+        assert_eq!(
+            dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2023-06-15 14:30:00"
+        );
     }
 
     #[test]

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -88,8 +88,7 @@ impl UploadPipeline {
 
         let (pause_tx, _pause_rx) = watch::channel(false);
 
-        let queue =
-            UploadQueue::new(store.clone(), upload.concurrency as usize);
+        let queue = UploadQueue::new(store.clone(), upload.concurrency as usize);
         let worker = Arc::new(UploadWorker::new(worker_config));
 
         Self {
@@ -248,12 +247,7 @@ mod tests {
                 .collect())
         }
 
-        fn update_status(
-            &self,
-            id: i64,
-            status: &str,
-            error: Option<&str>,
-        ) -> anyhow::Result<()> {
+        fn update_status(&self, id: i64, status: &str, error: Option<&str>) -> anyhow::Result<()> {
             let mut entries = self.entries.lock().unwrap();
             if let Some(e) = entries.iter_mut().find(|e| e.id == id) {
                 e.status = status.to_string();
@@ -262,11 +256,7 @@ mod tests {
             Ok(())
         }
 
-        fn mark_completed(
-            &self,
-            id: i64,
-            _asset_id: Option<&str>,
-        ) -> anyhow::Result<()> {
+        fn mark_completed(&self, id: i64, _asset_id: Option<&str>) -> anyhow::Result<()> {
             let mut entries = self.entries.lock().unwrap();
             if let Some(e) = entries.iter_mut().find(|e| e.id == id) {
                 e.status = "completed".to_string();
@@ -349,12 +339,7 @@ mod tests {
         let uploader: Arc<dyn AssetUploader> = Arc::new(InstantUploader);
         let server = ServerConfig::default();
         let upload = UploadConfig::default();
-        let pipeline = UploadPipeline::new(
-            store.clone(),
-            &server,
-            &upload,
-            uploader,
-        );
+        let pipeline = UploadPipeline::new(store.clone(), &server, &upload, uploader);
         (pipeline, store)
     }
 

--- a/src/upload/queue.rs
+++ b/src/upload/queue.rs
@@ -46,19 +46,10 @@ pub trait QueueStore: Send + Sync {
     fn dequeue_pending(&self, limit: usize) -> anyhow::Result<Vec<QueueEntry>>;
 
     /// Update the status (and optional error message) of a queue entry.
-    fn update_status(
-        &self,
-        id: i64,
-        status: &str,
-        error: Option<&str>,
-    ) -> anyhow::Result<()>;
+    fn update_status(&self, id: i64, status: &str, error: Option<&str>) -> anyhow::Result<()>;
 
     /// Mark a queue entry as completed and record the resulting asset ID.
-    fn mark_completed(
-        &self,
-        id: i64,
-        asset_id: Option<&str>,
-    ) -> anyhow::Result<()>;
+    fn mark_completed(&self, id: i64, asset_id: Option<&str>) -> anyhow::Result<()>;
 
     /// Return `true` if a file with this SHA-1 hash has already been
     /// successfully uploaded (exists in `uploaded_files`).
@@ -259,12 +250,7 @@ mod tests {
                 .collect())
         }
 
-        fn update_status(
-            &self,
-            id: i64,
-            status: &str,
-            error: Option<&str>,
-        ) -> anyhow::Result<()> {
+        fn update_status(&self, id: i64, status: &str, error: Option<&str>) -> anyhow::Result<()> {
             let mut entries = self.entries.lock().unwrap();
             if let Some(e) = entries.iter_mut().find(|e| e.id == id) {
                 e.status = status.to_string();
@@ -273,11 +259,7 @@ mod tests {
             Ok(())
         }
 
-        fn mark_completed(
-            &self,
-            id: i64,
-            _asset_id: Option<&str>,
-        ) -> anyhow::Result<()> {
+        fn mark_completed(&self, id: i64, _asset_id: Option<&str>) -> anyhow::Result<()> {
             let mut entries = self.entries.lock().unwrap();
             if let Some(e) = entries.iter_mut().find(|e| e.id == id) {
                 e.status = "completed".to_string();
@@ -287,12 +269,7 @@ mod tests {
         }
 
         fn is_file_uploaded(&self, hash: &str) -> anyhow::Result<bool> {
-            Ok(*self
-                .uploaded
-                .lock()
-                .unwrap()
-                .get(hash)
-                .unwrap_or(&false))
+            Ok(*self.uploaded.lock().unwrap().get(hash).unwrap_or(&false))
         }
 
         fn record_upload(
@@ -385,8 +362,7 @@ mod tests {
     fn process_file_missing_path_returns_error() {
         let store = Arc::new(MockStore::default());
         let queue = UploadQueue::new(store, 2);
-        let result =
-            queue.process_file(PathBuf::from("/nonexistent/photo.jpg"), None);
+        let result = queue.process_file(PathBuf::from("/nonexistent/photo.jpg"), None);
         assert!(result.is_err());
     }
 }

--- a/src/upload/worker.rs
+++ b/src/upload/worker.rs
@@ -99,11 +99,7 @@ pub trait AssetUploader: Send + Sync {
     ) -> anyhow::Result<Vec<BulkCheckResult>>;
 
     /// Get or create an album by name, then add an asset to it.
-    async fn add_asset_to_album(
-        &self,
-        _album_name: &str,
-        _asset_id: &str,
-    ) -> anyhow::Result<()> {
+    async fn add_asset_to_album(&self, _album_name: &str, _asset_id: &str) -> anyhow::Result<()> {
         Ok(()) // Default no-op for mock implementations
     }
 }
@@ -190,11 +186,7 @@ impl UploadWorker {
     ///
     /// `store`   — the queue/upload-record backend
     /// `uploader` — the Immich API client
-    pub async fn run(
-        &self,
-        store: Arc<dyn QueueStore>,
-        uploader: Arc<dyn AssetUploader>,
-    ) {
+    pub async fn run(&self, store: Arc<dyn QueueStore>, uploader: Arc<dyn AssetUploader>) {
         info!(
             concurrency = self.config.concurrency,
             device_id = %self.config.device_id,
@@ -416,7 +408,10 @@ async fn process_item(
 
             // Record in uploaded_files.
             // Strip the \\?\ extended-path prefix so DB queries match cleanly.
-            let clean_path = entry.file_path.strip_prefix(r"\\?\").unwrap_or(&entry.file_path);
+            let clean_path = entry
+                .file_path
+                .strip_prefix(r"\\?\")
+                .unwrap_or(&entry.file_path);
             if let Some(hash) = &entry.file_hash {
                 let size = entry.file_size.unwrap_or(0);
                 if let Err(e) = store.record_upload(
@@ -440,7 +435,10 @@ async fn process_item(
                 if let Ok(Some(folder)) = store.get_folder(folder_id) {
                     let album_name = resolve_album_name(&folder, &path, &file_meta);
                     if let Some(name) = album_name {
-                        if let Err(e) = uploader.add_asset_to_album(&name, &upload_result.asset_id).await {
+                        if let Err(e) = uploader
+                            .add_asset_to_album(&name, &upload_result.asset_id)
+                            .await
+                        {
                             warn!(
                                 id = entry.id,
                                 album = %name,
@@ -485,10 +483,7 @@ async fn process_item(
                 }
             }
 
-            if let Err(e) = store.mark_completed(
-                entry.id,
-                Some(&upload_result.asset_id),
-            ) {
+            if let Err(e) = store.mark_completed(entry.id, Some(&upload_result.asset_id)) {
                 error!(id = entry.id, error = %e, "Failed to mark entry completed");
             }
         }
@@ -517,9 +512,7 @@ async fn process_item(
 
                 // We set the retry_count via the error path; the DB
                 // implementation is expected to increment it on status update.
-                if let Err(db_err) =
-                    store.update_status(entry.id, "failed", Some(&error_msg))
-                {
+                if let Err(db_err) = store.update_status(entry.id, "failed", Some(&error_msg)) {
                     error!(id = entry.id, error = %db_err, "Failed to mark entry as failed");
                 }
             } else {
@@ -537,9 +530,7 @@ async fn process_item(
                 // The retry_count increment is handled by the DB layer via
                 // a dedicated "increment retry" update; here we just set
                 // status back to pending.
-                if let Err(db_err) =
-                    store.update_status(entry.id, "pending", Some(&error_msg))
-                {
+                if let Err(db_err) = store.update_status(entry.id, "pending", Some(&error_msg)) {
                     error!(id = entry.id, error = %db_err, "Failed to reset entry to pending");
                 }
             }
@@ -554,7 +545,9 @@ async fn process_item(
 /// Sequence (base = 1 s): 1 s, 2 s, 4 s, 8 s, 16 s, 32 s (capped).
 fn backoff_delay(retry: u32, base: Duration) -> Duration {
     const MAX_DELAY_SECS: u64 = 32;
-    let multiplier = 1u64.checked_shl(retry.saturating_sub(1)).unwrap_or(u64::MAX);
+    let multiplier = 1u64
+        .checked_shl(retry.saturating_sub(1))
+        .unwrap_or(u64::MAX);
     let secs = (base.as_secs() * multiplier).min(MAX_DELAY_SECS);
     Duration::from_secs(secs)
 }
@@ -618,9 +611,12 @@ pub fn trash_file(file_path: &std::path::Path, folder_root: &str) -> anyhow::Res
     let trash_root = root.join(TRASH_DIR_NAME);
 
     // Compute relative path from folder root.
-    let relative = file_path
-        .strip_prefix(root)
-        .unwrap_or_else(|_| file_path.file_name().map(std::path::Path::new).unwrap_or(file_path));
+    let relative = file_path.strip_prefix(root).unwrap_or_else(|_| {
+        file_path
+            .file_name()
+            .map(std::path::Path::new)
+            .unwrap_or(file_path)
+    });
 
     let dest = trash_root.join(relative);
 
@@ -660,10 +656,7 @@ pub fn trash_file(file_path: &std::path::Path, folder_root: &str) -> anyhow::Res
 /// `retention_days`.  Removes empty directories afterwards.
 ///
 /// Called on startup and periodically from the app's main loop.
-pub fn cleanup_trash(
-    folders: &[crate::db::WatchedFolder],
-    retention_days: u32,
-) {
+pub fn cleanup_trash(folders: &[crate::db::WatchedFolder], retention_days: u32) {
     use std::time::{Duration, SystemTime};
 
     let max_age = Duration::from_secs(retention_days as u64 * 86400);
@@ -783,12 +776,7 @@ mod tests {
                 .collect())
         }
 
-        fn update_status(
-            &self,
-            id: i64,
-            status: &str,
-            error: Option<&str>,
-        ) -> anyhow::Result<()> {
+        fn update_status(&self, id: i64, status: &str, error: Option<&str>) -> anyhow::Result<()> {
             let mut entries = self.entries.lock().unwrap();
             if let Some(e) = entries.iter_mut().find(|e| e.id == id) {
                 e.status = status.to_string();
@@ -800,11 +788,7 @@ mod tests {
             Ok(())
         }
 
-        fn mark_completed(
-            &self,
-            id: i64,
-            _asset_id: Option<&str>,
-        ) -> anyhow::Result<()> {
+        fn mark_completed(&self, id: i64, _asset_id: Option<&str>) -> anyhow::Result<()> {
             let mut entries = self.entries.lock().unwrap();
             if let Some(e) = entries.iter_mut().find(|e| e.id == id) {
                 e.status = "completed".to_string();
@@ -960,7 +944,12 @@ mod tests {
             })
             .unwrap();
 
-        let entry = store.dequeue_pending(1).unwrap().into_iter().next().unwrap();
+        let entry = store
+            .dequeue_pending(1)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
 
         let config = WorkerConfig {
             concurrency: 1,

--- a/src/watch/device.rs
+++ b/src/watch/device.rs
@@ -5,17 +5,16 @@
 // DBT_DEVICEREMOVECOMPLETE and forwards typed DeviceEvent values through
 // a tokio channel.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::WindowsAndMessaging::{
-    CreateWindowExW, DefWindowProcW, DestroyWindow, GetMessageW, PostMessageW,
-    RegisterClassW, HWND_MESSAGE, MSG, WINDOW_EX_STYLE, WINDOW_STYLE, WM_QUIT,
-    WNDCLASSW,
+    CreateWindowExW, DefWindowProcW, DestroyWindow, GetMessageW, PostMessageW, RegisterClassW,
+    HWND_MESSAGE, MSG, WINDOW_EX_STYLE, WINDOW_STYLE, WM_QUIT, WNDCLASSW,
 };
 
 /// Events emitted by the device monitor.
@@ -156,9 +155,7 @@ fn run_device_monitor_loop(
         *cell.borrow_mut() = Some(event_tx);
     });
 
-    let class_name_wide: Vec<u16> = "ImmichSyncDevMon\0"
-        .encode_utf16()
-        .collect();
+    let class_name_wide: Vec<u16> = "ImmichSyncDevMon\0".encode_utf16().collect();
 
     let wc = WNDCLASSW {
         lpfnWndProc: Some(device_wnd_proc),

--- a/src/watch/filter.rs
+++ b/src/watch/filter.rs
@@ -126,9 +126,10 @@ impl FileFilter {
     /// - Custom include globs are configured and none of them match the path
     pub fn should_include(&self, path: &Path) -> bool {
         // Skip anything inside the trash directory.
-        if path.components().any(|c| {
-            c.as_os_str() == crate::upload::worker::TRASH_DIR_NAME
-        }) {
+        if path
+            .components()
+            .any(|c| c.as_os_str() == crate::upload::worker::TRASH_DIR_NAME)
+        {
             debug!("Excluding (inside trash directory): {:?}", path);
             return false;
         }
@@ -298,8 +299,7 @@ mod tests {
 
     #[test]
     fn test_custom_exclude_pattern() {
-        let filter =
-            FileFilter::new().with_exclude_patterns(vec!["**/thumbnails/**".to_string()]);
+        let filter = FileFilter::new().with_exclude_patterns(vec!["**/thumbnails/**".to_string()]);
         let dir = tempfile::tempdir().unwrap();
         let thumb_dir = dir.path().join("thumbnails");
         std::fs::create_dir(&thumb_dir).unwrap();

--- a/src/watch/folder.rs
+++ b/src/watch/folder.rs
@@ -179,8 +179,7 @@ pub(crate) async fn write_complete_and_send(path: PathBuf, tx: mpsc::Sender<Watc
         if start.elapsed() >= MAX_WRITE_WAIT {
             warn!(
                 "Write-completion timeout for {:?} after {:?}",
-                path,
-                MAX_WRITE_WAIT
+                path, MAX_WRITE_WAIT
             );
             let _ = tx
                 .send(WatchEvent::Error(format!(

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -134,13 +134,8 @@ impl WatchEngine {
         let tx = self.event_tx.clone();
 
         let watcher: ActiveWatcher = if is_network {
-            let nw = NetworkWatcher::new(
-                path.clone(),
-                filter,
-                tx,
-                DEFAULT_POLL_INTERVAL,
-                rt_handle,
-            );
+            let nw =
+                NetworkWatcher::new(path.clone(), filter, tx, DEFAULT_POLL_INTERVAL, rt_handle);
             nw.start().map_err(|e| WatchError::StartFailed {
                 path: path.clone(),
                 source: e,
@@ -275,7 +270,12 @@ mod tests {
         let handle = test_rt_handle();
 
         engine
-            .add_folder(dir.path().to_path_buf(), FileFilter::new(), false, handle.clone())
+            .add_folder(
+                dir.path().to_path_buf(),
+                FileFilter::new(),
+                false,
+                handle.clone(),
+            )
             .expect("add_folder should succeed");
 
         assert_eq!(engine.watcher_count(), 1);
@@ -296,7 +296,12 @@ mod tests {
         let handle = test_rt_handle();
 
         engine
-            .add_folder(dir.path().to_path_buf(), FileFilter::new(), false, handle.clone())
+            .add_folder(
+                dir.path().to_path_buf(),
+                FileFilter::new(),
+                false,
+                handle.clone(),
+            )
             .expect("first add should succeed");
 
         let result = engine.add_folder(dir.path().to_path_buf(), FileFilter::new(), false, handle);
@@ -325,7 +330,12 @@ mod tests {
         let handle = test_rt_handle();
 
         engine
-            .add_folder(dir1.path().to_path_buf(), FileFilter::new(), false, handle.clone())
+            .add_folder(
+                dir1.path().to_path_buf(),
+                FileFilter::new(),
+                false,
+                handle.clone(),
+            )
             .unwrap();
         engine
             .add_folder(dir2.path().to_path_buf(), FileFilter::new(), false, handle)


### PR DESCRIPTION
## Summary

Mechanical `cargo fmt --all` sweep + flip the fmt check in `ci.yml` from informational to gating.

## Closes

- #8

## What changed

- All `.rs` source files reformatted to rustfmt defaults.
- `.github/workflows/ci.yml` — removed `continue-on-error: true` on the Format check step.

No logic changes; diff is pure whitespace + workflow YAML edit.

## Test plan

- [x] `cargo check` clean on the rebased tree (69 pre-existing warnings, none new — tracked in #9)
- [ ] CI build & test green
- [ ] Verify the Format check actually gates (i.e., a follow-up PR with deliberately-misformatted code should fail CI)
- [ ] First end-to-end auto-merge test of the new check-registration logic from PR #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)