### PR TITLE
feat: configurable update source (#12)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -654,11 +654,12 @@ impl App {
         self.last_update_check = Instant::now();
 
         let repo = self.config.advanced.update_repo.clone();
+        let channel = self.config.advanced.update_channel.clone();
         self.runtime.spawn(async move {
             if with_delay {
                 tokio::time::sleep(updater::STARTUP_DELAY).await;
             }
-            let result = updater::check_for_update(&repo).await;
+            let result = updater::check_for_update(&repo, &channel).await;
             let _ = tx.send(result);
         });
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -353,10 +353,12 @@ impl App {
                         continue;
                     }
                     let is_network = folder.watch_mode == crate::db::WatchMode::Poll;
-                    let includes =
-                        crate::watch::filter::parse_patterns_json(folder.include_patterns.as_deref());
-                    let excludes =
-                        crate::watch::filter::parse_patterns_json(folder.exclude_patterns.as_deref());
+                    let includes = crate::watch::filter::parse_patterns_json(
+                        folder.include_patterns.as_deref(),
+                    );
+                    let excludes = crate::watch::filter::parse_patterns_json(
+                        folder.exclude_patterns.as_deref(),
+                    );
                     let filter = FileFilter::new()
                         .with_include_patterns(includes)
                         .with_exclude_patterns(excludes);

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,7 +203,16 @@ pub struct AdvancedConfig {
     pub update_check_interval_hours: u32,
 
     /// GitHub repository to check for updates (format: `owner/repo`).
+    /// Public repos only. Anything else (URL, SSH ref, hostname) is rejected
+    /// at load time and the update check is disabled for the session.
     pub update_repo: String,
+
+    /// Update channel. One of:
+    ///   - `"latest"`     ... track the latest published release (default)
+    ///   - `"prerelease"` ... track latest including prereleases
+    ///   - `"none"`       ... disable update checks entirely
+    ///   - `"vX.Y.Z"`     ... pin to a specific tag, never offer newer
+    pub update_channel: String,
 }
 
 impl Default for AdvancedConfig {
@@ -214,7 +223,8 @@ impl Default for AdvancedConfig {
             write_settle_ms: 2000,
             check_for_updates: true,
             update_check_interval_hours: 24,
-            update_repo: "gumbees/immichsync".to_string(),
+            update_repo: "bees-roadhouse/immichsync".to_string(),
+            update_channel: "latest".to_string(),
         }
     }
 }
@@ -379,6 +389,8 @@ mod tests {
         assert_eq!(cfg.advanced.log_level, "info");
         assert_eq!(cfg.advanced.poll_interval_secs, 30);
         assert_eq!(cfg.advanced.write_settle_ms, 2000);
+        assert_eq!(cfg.advanced.update_repo, "bees-roadhouse/immichsync");
+        assert_eq!(cfg.advanced.update_channel, "latest");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,10 +326,10 @@ fn check_for_update_on_startup() {
         }
     };
 
-    let repo = config::Config::load()
-        .map(|c| c.advanced.update_repo)
+    let (repo, channel) = config::Config::load()
+        .map(|c| (c.advanced.update_repo, c.advanced.update_channel))
         .unwrap_or_default();
-    let result = rt.block_on(updater::check_for_update(&repo));
+    let result = rt.block_on(updater::check_for_update(&repo, &channel));
 
     match result {
         updater::UpdateCheckResult::Available(info) => {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -92,6 +92,9 @@ pub fn show_settings(config: Config, result_tx: Option<Sender<Config>>) {
         check_for_updates: config.advanced.check_for_updates,
         update_check_interval_hours: config.advanced.update_check_interval_hours,
         update_repo: config.advanced.update_repo.clone(),
+        update_channel_mode: ChannelMode::from_str(&config.advanced.update_channel),
+        update_tag_pin: ChannelMode::extract_tag(&config.advanced.update_channel),
+        update_channel_error: String::new(),
 
         // Watch Folders tab
         folders,
@@ -125,6 +128,48 @@ enum Tab {
     Advanced,
 }
 
+// ── Channel mode (UI representation of update_channel) ──────────────────────
+
+/// UI-side channel selector. Maps onto `config.advanced.update_channel`
+/// (which is the raw string the updater consumes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChannelMode {
+    Latest,
+    Prerelease,
+    PinToTag,
+    Disabled,
+}
+
+impl ChannelMode {
+    fn from_str(s: &str) -> Self {
+        match s.trim() {
+            "prerelease" => ChannelMode::Prerelease,
+            "none" => ChannelMode::Disabled,
+            "" | "latest" => ChannelMode::Latest,
+            other if other.starts_with('v') => ChannelMode::PinToTag,
+            _ => ChannelMode::Latest,
+        }
+    }
+
+    /// Pull the tag out if the raw channel string is a pin; otherwise empty.
+    fn extract_tag(s: &str) -> String {
+        if s.trim().starts_with('v') {
+            s.trim().to_string()
+        } else {
+            String::new()
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            ChannelMode::Latest => "Latest stable",
+            ChannelMode::Prerelease => "Latest (including prereleases)",
+            ChannelMode::PinToTag => "Pin to tag",
+            ChannelMode::Disabled => "Disabled",
+        }
+    }
+}
+
 // ── Settings app state ──────────────────────────────────────────────────────
 
 struct SettingsApp {
@@ -151,6 +196,9 @@ struct SettingsApp {
     check_for_updates: bool,
     update_check_interval_hours: u32,
     update_repo: String,
+    update_channel_mode: ChannelMode,
+    update_tag_pin: String,
+    update_channel_error: String,
 
     // Watch Folders tab
     folders: Vec<WatchedFolder>,
@@ -185,8 +233,9 @@ impl eframe::App for SettingsApp {
             ui.add_space(4.0);
             ui.horizontal(|ui| {
                 if ui.button("Save").clicked() {
-                    self.save_config();
-                    ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                    if self.save_config() {
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
                 }
                 if ui.button("Cancel").clicked() {
                     ctx.send_viewport_cmd(egui::ViewportCommand::Close);
@@ -507,6 +556,38 @@ impl SettingsApp {
                     ui.label("Repository:");
                     ui.text_edit_singleline(&mut self.update_repo);
                 });
+                ui.horizontal(|ui| {
+                    ui.label("Channel:");
+                    egui::ComboBox::from_id_salt("update_channel")
+                        .selected_text(self.update_channel_mode.label())
+                        .show_ui(ui, |ui| {
+                            for mode in [
+                                ChannelMode::Latest,
+                                ChannelMode::Prerelease,
+                                ChannelMode::PinToTag,
+                                ChannelMode::Disabled,
+                            ] {
+                                ui.selectable_value(
+                                    &mut self.update_channel_mode,
+                                    mode,
+                                    mode.label(),
+                                );
+                            }
+                        });
+                });
+                if self.update_channel_mode == ChannelMode::PinToTag {
+                    ui.horizontal(|ui| {
+                        ui.label("Tag:");
+                        ui.text_edit_singleline(&mut self.update_tag_pin);
+                        ui.label("(e.g. v0.1.8)");
+                    });
+                }
+                if !self.update_channel_error.is_empty() {
+                    ui.colored_label(
+                        egui::Color32::from_rgb(220, 80, 80),
+                        &self.update_channel_error,
+                    );
+                }
             });
         });
         ui.add_enabled_ui(self.show_notifications, |ui| {
@@ -554,7 +635,30 @@ impl SettingsApp {
         }
     }
 
-    fn save_config(&mut self) {
+    fn save_config(&mut self) -> bool {
+        // Validate update settings before touching config. Bad values keep the
+        // window open with a visible error so the user can correct them.
+        self.update_channel_error.clear();
+        let repo_trim = self.update_repo.trim().to_string();
+        if !repo_trim.is_empty() && !crate::updater::is_valid_repo(&repo_trim) {
+            self.update_channel_error =
+                "Repository must be in 'owner/name' format (public github.com only).".to_string();
+            self.active_tab = Tab::Advanced;
+            return false;
+        }
+        self.update_repo = repo_trim;
+
+        if self.update_channel_mode == ChannelMode::PinToTag {
+            let tag = self.update_tag_pin.trim().to_string();
+            if crate::updater::Channel::parse(&tag).is_none() {
+                self.update_channel_error =
+                    "Tag pin must look like 'vX.Y.Z' (or 'vX.Y.Z-prerelease').".to_string();
+                self.active_tab = Tab::Advanced;
+                return false;
+            }
+            self.update_tag_pin = tag;
+        }
+
         // Apply UI state back to config.
         self.config.server.url = self.server_url.clone();
         self.config.server.api_key = self.api_key.clone();
@@ -571,6 +675,12 @@ impl SettingsApp {
         self.config.advanced.check_for_updates = self.check_for_updates;
         self.config.advanced.update_check_interval_hours = self.update_check_interval_hours;
         self.config.advanced.update_repo = self.update_repo.clone();
+        self.config.advanced.update_channel = match self.update_channel_mode {
+            ChannelMode::Latest => "latest".to_string(),
+            ChannelMode::Prerelease => "prerelease".to_string(),
+            ChannelMode::Disabled => "none".to_string(),
+            ChannelMode::PinToTag => self.update_tag_pin.trim().to_string(),
+        };
 
         self.config.ui.start_with_windows = self.autostart;
         self.config.ui.minimize_to_tray = self.minimize_to_tray;
@@ -596,6 +706,8 @@ impl SettingsApp {
         if let Some(ref tx) = self.result_tx {
             let _ = tx.send(self.config.clone());
         }
+
+        true
     }
 }
 

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -13,16 +13,11 @@ use tracing::{debug, info, warn};
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const DEFAULT_REPO: &str = "gumbees/immichsync";
+const DEFAULT_REPO: &str = "bees-roadhouse/immichsync";
 const ASSET_NAME: &str = "immichsync.exe";
 
 /// Delay before the first automatic update check after startup.
 pub const STARTUP_DELAY: Duration = Duration::from_secs(30);
-
-/// Build the GitHub API URL for the latest release of the given repo.
-fn github_api_url(repo: &str) -> String {
-    format!("https://api.github.com/repos/{repo}/releases/latest")
-}
 
 /// Build the check interval from config hours (0 = disabled).
 pub fn check_interval_from_hours(hours: u32) -> Duration {
@@ -33,6 +28,105 @@ pub fn check_interval_from_hours(hours: u32) -> Duration {
     }
 }
 
+// ─── Repo + channel parsing ─────────────────────────────────────────────────
+
+/// Validate a GitHub `owner/repo` string.
+///
+/// Accepts ASCII alphanumerics plus `.`, `_`, `-` in each segment. Rejects
+/// URLs, SSH refs, enterprise hostnames, and anything else that's not a bare
+/// `owner/repo`. v1 is public github.com only.
+pub fn is_valid_repo(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('/').collect();
+    if parts.len() != 2 {
+        return false;
+    }
+    parts.iter().all(|seg| {
+        !seg.is_empty()
+            && seg
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+    })
+}
+
+/// Validate a pinned tag of the form `vX.Y.Z` or `vX.Y.Z-prerelease`.
+fn is_valid_tag_pin(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix('v') else {
+        return false;
+    };
+    // Split off optional `-prerelease` suffix first.
+    let (core, pre) = match rest.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (rest, None),
+    };
+    let parts: Vec<&str> = core.split('.').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    if !parts
+        .iter()
+        .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+    {
+        return false;
+    }
+    if let Some(p) = pre {
+        if p.is_empty()
+            || !p
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// Update channel resolved from config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Channel {
+    /// Track the latest published release.
+    Latest,
+    /// Track latest including prereleases.
+    Prerelease,
+    /// Pin to a specific tag.
+    Tag(String),
+    /// Update checks disabled.
+    None,
+}
+
+impl Channel {
+    /// Parse a channel string from config.
+    ///
+    /// Returns `None` if the string is not a recognised channel or valid tag
+    /// pin. Callers should treat unparseable channels as "disable for the
+    /// session" and log a warning.
+    pub fn parse(s: &str) -> Option<Self> {
+        let s = s.trim();
+        match s {
+            "latest" | "" => Some(Channel::Latest),
+            "prerelease" => Some(Channel::Prerelease),
+            "none" => Some(Channel::None),
+            other if is_valid_tag_pin(other) => Some(Channel::Tag(other.to_string())),
+            _ => None,
+        }
+    }
+}
+
+/// Build the GitHub API URL for the resolved channel.
+fn channel_api_url(repo: &str, channel: &Channel) -> Option<String> {
+    match channel {
+        Channel::Latest => Some(format!(
+            "https://api.github.com/repos/{repo}/releases/latest"
+        )),
+        Channel::Prerelease => Some(format!(
+            "https://api.github.com/repos/{repo}/releases?per_page=10"
+        )),
+        Channel::Tag(tag) => Some(format!(
+            "https://api.github.com/repos/{repo}/releases/tags/{tag}"
+        )),
+        Channel::None => None,
+    }
+}
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -40,6 +134,16 @@ struct GitHubRelease {
     tag_name: String,
     body: Option<String>,
     assets: Vec<GitHubAsset>,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRepoInfo {
+    #[serde(default)]
+    private: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -81,6 +185,18 @@ pub enum UpdateError {
     #[error("invalid version in release tag: {0}")]
     InvalidVersion(String),
 
+    #[error("no matching release for channel")]
+    NoRelease,
+
+    #[error("invalid repo format: {0}")]
+    InvalidRepo(String),
+
+    #[error("repo is private or not found: {0}")]
+    PrivateOrMissing(String),
+
+    #[error("invalid channel: {0}")]
+    InvalidChannel(String),
+
     #[error("file error: {0}")]
     File(#[from] std::io::Error),
 
@@ -90,32 +206,87 @@ pub enum UpdateError {
 
 // ─── Check ───────────────────────────────────────────────────────────────────
 
-/// Check GitHub for a newer release.
+/// Check GitHub for a newer release on the given channel.
 ///
-/// `repo` is the GitHub `owner/repo` string (e.g. `"gumbees/immichsync"`).
-/// Pass an empty string to use the default.
-pub async fn check_for_update(repo: &str) -> UpdateCheckResult {
+/// `repo` is the GitHub `owner/repo` string. Empty falls back to the
+/// compiled-in default. `channel_str` is the raw config value
+/// (`"latest"`, `"prerelease"`, `"none"`, or `"vX.Y.Z"`). Unparseable
+/// channels and invalid repos resolve to `Failed(...)`; the caller
+/// should log and disable updates for the session.
+pub async fn check_for_update(repo: &str, channel_str: &str) -> UpdateCheckResult {
     let repo = if repo.is_empty() { DEFAULT_REPO } else { repo };
-    match check_inner(repo).await {
+
+    if !is_valid_repo(repo) {
+        return UpdateCheckResult::Failed(format!("invalid repo format: {repo}"));
+    }
+
+    let channel = match Channel::parse(channel_str) {
+        Some(c) => c,
+        None => {
+            return UpdateCheckResult::Failed(format!(
+                "invalid update channel: '{channel_str}' (expected 'latest', 'prerelease', 'none', or 'vX.Y.Z')"
+            ));
+        }
+    };
+
+    if channel == Channel::None {
+        debug!("Update channel is 'none', skipping check");
+        return UpdateCheckResult::UpToDate;
+    }
+
+    match check_inner(repo, &channel).await {
         Ok(result) => result,
         Err(e) => UpdateCheckResult::Failed(e.to_string()),
     }
 }
 
-async fn check_inner(repo: &str) -> Result<UpdateCheckResult, UpdateError> {
-    let url = github_api_url(repo);
+async fn check_inner(repo: &str, channel: &Channel) -> Result<UpdateCheckResult, UpdateError> {
     let client = reqwest::Client::builder()
         .user_agent(format!("ImmichSync/{}", env!("CARGO_PKG_VERSION")))
         .timeout(Duration::from_secs(15))
         .build()?;
 
-    let release: GitHubRelease = client
-        .get(&url)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    // Pre-flight: confirm the repo is public and reachable. If it 404s or
+    // comes back private, disable updates for the session.
+    let repo_url = format!("https://api.github.com/repos/{repo}");
+    let repo_resp = client.get(&repo_url).send().await?;
+    if repo_resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(UpdateError::PrivateOrMissing(repo.to_string()));
+    }
+    let repo_info: GitHubRepoInfo = repo_resp.error_for_status()?.json().await?;
+    if repo_info.private {
+        return Err(UpdateError::PrivateOrMissing(repo.to_string()));
+    }
+
+    // Resolve the release endpoint for this channel.
+    let url = channel_api_url(repo, channel).expect("None channel handled above");
+
+    let release = match channel {
+        Channel::Prerelease => {
+            // List endpoint returns an array; pick the first non-draft entry.
+            let releases: Vec<GitHubRelease> = client
+                .get(&url)
+                .send()
+                .await?
+                .error_for_status()?
+                .json()
+                .await?;
+            releases
+                .into_iter()
+                .find(|r| !r.draft)
+                .ok_or(UpdateError::NoRelease)?
+        }
+        Channel::Latest | Channel::Tag(_) => {
+            let resp = client.get(&url).send().await?;
+            if matches!(channel, Channel::Tag(_))
+                && resp.status() == reqwest::StatusCode::NOT_FOUND
+            {
+                return Err(UpdateError::NoRelease);
+            }
+            resp.error_for_status()?.json::<GitHubRelease>().await?
+        }
+        Channel::None => unreachable!(),
+    };
 
     // Parse version from tag (strip leading 'v' if present).
     let tag = release
@@ -129,6 +300,8 @@ async fn check_inner(repo: &str) -> Result<UpdateCheckResult, UpdateError> {
     let current_ver = semver::Version::parse(current_str)
         .map_err(|_| UpdateError::InvalidVersion(current_str.to_string()))?;
 
+    // No-downgrade policy: if the resolved release is at or below the running
+    // binary, we just stay where we are (regardless of channel).
     if remote_ver <= current_ver {
         debug!(current = %current_ver, remote = %remote_ver, "Already up to date");
         return Ok(UpdateCheckResult::UpToDate);
@@ -153,6 +326,7 @@ async fn check_inner(repo: &str) -> Result<UpdateCheckResult, UpdateError> {
         current = %current_ver,
         new = %remote_ver,
         size = asset.size,
+        prerelease = release.prerelease,
         "Update available"
     );
 
@@ -296,4 +470,94 @@ pub fn relaunch_self() -> ! {
 
     let _ = std::process::Command::new(&exe).args(&args).spawn();
     std::process::exit(0);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_repo_accepts_owner_slash_repo() {
+        assert!(is_valid_repo("bees-roadhouse/immichsync"));
+        assert!(is_valid_repo("gumbees/immichsync"));
+        assert!(is_valid_repo("user.name/repo.name"));
+        assert!(is_valid_repo("u_1/r_2"));
+        assert!(is_valid_repo("a/b"));
+    }
+
+    #[test]
+    fn valid_repo_rejects_garbage() {
+        assert!(!is_valid_repo(""));
+        assert!(!is_valid_repo("no-slash"));
+        assert!(!is_valid_repo("/leading-slash"));
+        assert!(!is_valid_repo("trailing-slash/"));
+        assert!(!is_valid_repo("too/many/slashes"));
+        assert!(!is_valid_repo("https://github.com/owner/repo"));
+        assert!(!is_valid_repo("git@github.com:owner/repo"));
+        assert!(!is_valid_repo("owner repo/has spaces"));
+        assert!(!is_valid_repo("owner/repo$"));
+    }
+
+    #[test]
+    fn channel_parse_handles_known_literals() {
+        assert_eq!(Channel::parse("latest"), Some(Channel::Latest));
+        assert_eq!(Channel::parse(""), Some(Channel::Latest));
+        assert_eq!(Channel::parse("prerelease"), Some(Channel::Prerelease));
+        assert_eq!(Channel::parse("none"), Some(Channel::None));
+        assert_eq!(Channel::parse("  latest  "), Some(Channel::Latest));
+    }
+
+    #[test]
+    fn channel_parse_accepts_tag_pins() {
+        assert_eq!(
+            Channel::parse("v0.1.8"),
+            Some(Channel::Tag("v0.1.8".to_string()))
+        );
+        assert_eq!(
+            Channel::parse("v1.0.0-rc.1"),
+            Some(Channel::Tag("v1.0.0-rc.1".to_string()))
+        );
+        assert_eq!(
+            Channel::parse("v10.20.30"),
+            Some(Channel::Tag("v10.20.30".to_string()))
+        );
+    }
+
+    #[test]
+    fn channel_parse_rejects_bogus() {
+        assert_eq!(Channel::parse("stable"), None);
+        assert_eq!(Channel::parse("1.0.0"), None); // missing 'v'
+        assert_eq!(Channel::parse("v1.0"), None); // not three segments
+        assert_eq!(Channel::parse("vX.Y.Z"), None); // non-numeric
+        assert_eq!(Channel::parse("v1.0.0-"), None); // empty prerelease
+    }
+
+    #[test]
+    fn channel_api_url_picks_right_endpoint() {
+        let repo = "bees-roadhouse/immichsync";
+        assert_eq!(
+            channel_api_url(repo, &Channel::Latest),
+            Some("https://api.github.com/repos/bees-roadhouse/immichsync/releases/latest".into())
+        );
+        assert!(channel_api_url(repo, &Channel::Prerelease)
+            .unwrap()
+            .contains("/releases?"));
+        assert_eq!(
+            channel_api_url(repo, &Channel::Tag("v0.1.8".into())),
+            Some(
+                "https://api.github.com/repos/bees-roadhouse/immichsync/releases/tags/v0.1.8"
+                    .into()
+            )
+        );
+        assert_eq!(channel_api_url(repo, &Channel::None), None);
+    }
+
+    #[test]
+    fn check_interval_zero_is_disabled() {
+        assert_eq!(check_interval_from_hours(0), Duration::from_secs(u64::MAX));
+        assert_eq!(check_interval_from_hours(1), Duration::from_secs(3600));
+        assert_eq!(check_interval_from_hours(24), Duration::from_secs(86400));
+    }
 }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -278,8 +278,7 @@ async fn check_inner(repo: &str, channel: &Channel) -> Result<UpdateCheckResult,
         }
         Channel::Latest | Channel::Tag(_) => {
             let resp = client.get(&url).send().await?;
-            if matches!(channel, Channel::Tag(_))
-                && resp.status() == reqwest::StatusCode::NOT_FOUND
+            if matches!(channel, Channel::Tag(_)) && resp.status() == reqwest::StatusCode::NOT_FOUND
             {
                 return Err(UpdateError::NoRelease);
             }


### PR DESCRIPTION
## Summary

Replaces the hardcoded `gumbees/immichsync` update target with a fully configurable source. The updater now reads two config fields and supports four channel modes.

`Closes #12`

## Schema change (`config.toml` `[advanced]`)

| Field | Type | Default | Notes |
|---|---|---|---|
| `update_repo` | string | `bees-roadhouse/immichsync` | `owner/name`, public github.com only. Was `gumbees/immichsync`. |
| `update_channel` | string | `latest` | New field. One of `latest`, `prerelease`, `none`, or `vX.Y.Z` tag pin. |

Both fields use `#[serde(default)]`, so existing `config.toml` files without these keys keep working ... they pick up the new defaults on load. The default channel `latest` preserves current behaviour. The default repo `bees-roadhouse/immichsync` is the canonical home now; users on the old `gumbees/immichsync` keep working until they update.

## Updater behaviour

- `latest` ... hits `/releases/latest` (same as before).
- `prerelease` ... hits `/releases?per_page=10` and picks the first non-draft entry.
- `vX.Y.Z` ... hits `/releases/tags/{tag}`. No-downgrade policy: if the pinned tag's version is `<=` the running binary, the updater stays put.
- `none` ... short-circuits to `UpToDate` with no network calls.
- Pre-flight `GET /repos/{repo}` rejects private + 404 repos with a warning, no auth attempts. No PAT support, no auth headers ... matches issue's threat model.
- Invalid `update_repo` (URLs, SSH refs, enterprise hosts) is rejected at the updater entry point and returns `Failed(...)` so the periodic loop logs and moves on.

## UI design (Settings, Advanced tab)

Under "Automatically check for updates":

- **Channel** dropdown: `Latest stable` / `Latest (including prereleases)` / `Pin to tag` / `Disabled`.
- **Tag** input field appears only when `Pin to tag` is selected, with placeholder `(e.g. v0.1.8)`.
- Inline red error on Save if the repo isn't `owner/name` shape or the tag pin isn't `vX.Y.Z`-shaped. The window stays open until the user fixes it.
- Existing repo input + interval spinner unchanged.

## Test plan

- [x] Default config (`update_repo = "bees-roadhouse/immichsync"`, `update_channel = "latest"`) ... behaves identically to pre-change (`/releases/latest`).
- [x] Round-trip TOML serialization preserves both fields.
- [x] `Channel::parse` accepts `latest`, `prerelease`, `none`, `""`, `v0.1.8`, `v1.0.0-rc.1`; rejects `stable`, `1.0.0`, `v1.0`, `vX.Y.Z`, `v1.0.0-`.
- [x] `is_valid_repo` accepts `owner/repo`, rejects URLs, SSH refs, multi-slash, empty segments, special chars.
- [x] `channel_api_url` routes to `/releases/latest`, `/releases?...`, `/releases/tags/{tag}`, or `None` for the four modes.
- [x] `cargo test --locked` passes (63 tests, including 7 new updater tests).
- [x] `cargo check --release` passes.
- [x] Manual: pin to current version, confirm `UpToDate`.
- [x] Manual: pin to a non-existent tag, confirm graceful `Failed` log, no crash.
- [x] Manual: set channel to `none`, confirm no `api.github.com` traffic.
- [x] Manual: settings UI ... pick each channel mode, save, reopen, verify persistence.

## Files

- `src/config.rs` ... new `update_channel` field, default repo flipped to `bees-roadhouse/immichsync`.
- `src/updater.rs` ... `Channel` enum, `is_valid_repo`, `is_valid_tag_pin`, `channel_api_url`, rewritten `check_for_update` taking `(repo, channel)` with pre-flight repo check + per-channel endpoint routing.
- `src/app.rs`, `src/main.rs` ... thread the channel through.
- `src/ui/settings.rs` ... `ChannelMode` enum, dropdown + conditional tag input, Save-time validation that keeps the window open on error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)