### PR TITLE
improvement: bump to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "immichsync"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "immichsync"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2021"
 description = "Windows system tray app that syncs photos/videos to Immich"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Version bump from `0.1.8` -> `0.2.0`, rolling up the minor release. Closes nothing (release-prep PR; the rolled-up issues are already closed by their respective feature PRs).

Per the [Branching Strategy](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) two-tier model, `feature/` and `improvement/` work bumps the minor.

## Rolled up in 0.2.0

Features:
- feat(#3): per-folder include/exclude glob patterns (#31)
- feat(#4): watcher health monitoring + auto-restart (#35)
- feat(#12): configurable update source with channel + tag pin (#32)
- feat(#26): ignore online cloud-placeholder files + path/size/mtime dedup (#33)
- feat(#38): brand icon with rotating tray animation + offline state (#40)

Refactors:
- refactor(#20, #29): Windows-standard install layout + Apps & Features uninstall entry (#36)

Infra / housekeeping:
- (#9 clippy gate + dead-code cleanup may also be included by release-cut time)
- stable artifact headers (#34)
- slim CI (#30)
- fmt sweep + gating (#28)
- workflow check-registration (#27)

GitHub Release notes auto-generate from the PRs on the `release` cut via `generate_release_notes: true` in `release.yml`, so no `CHANGELOG.md` is being added here.

## Files changed

- `Cargo.toml`: `version = "0.1.8"` -> `version = "0.2.0"` (one line)
- `Cargo.lock`: workspace member pin refreshed via `cargo check`

No other version strings needed updating. Test fixtures and the UI placeholder in `src/updater.rs` / `src/ui/settings.rs` reference `v0.1.8` as a sample tag string (not as "current version"), so those stay as-is.

## Test plan

- [x] `cargo check --locked` clean
- [x] `cargo check --release --locked` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --locked` ... 111 passed
- [ ] CI: `Build & test` green
- [ ] CI: `Regenerate SBOM and STRUCTURE` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)