### PR TITLE
release: 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "immichsync"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "immichsync"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Windows system tray app that syncs photos/videos to Immich"
 license = "GPL-3.0-only"

--- a/src/app.rs
+++ b/src/app.rs
@@ -228,8 +228,7 @@ impl App {
                 while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).into() {
                     if msg.message == WM_QUIT {
                         info!("WM_QUIT received");
-                        self.shutdown();
-                        return;
+                        self.shutdown_and_exit();
                     }
                     let _ = TranslateMessage(&msg);
                     DispatchMessageW(&msg);
@@ -254,8 +253,7 @@ impl App {
             }
             if quit {
                 info!("Quit requested from tray");
-                self.shutdown();
-                return;
+                self.shutdown_and_exit();
             }
 
             // Check for config updates from the settings window.
@@ -953,9 +951,11 @@ impl App {
         });
     }
 
-    /// Stop all background work.
+    /// Stop all background work, waiting briefly for the upload worker to
+    /// quiesce. Used by the relaunch path so the new process can take
+    /// ownership of `state.db` without fighting a still-flushing writer.
     fn shutdown(&mut self) {
-        info!("Shutting down");
+        info!("Shutting down (graceful)");
 
         if let Some(ref mut engine) = self.watch_engine {
             engine.stop_all();
@@ -969,6 +969,32 @@ impl App {
         }
 
         info!("Shutdown complete");
+    }
+
+    /// Immediate-exit path for user-initiated Quit and WM_QUIT.
+    ///
+    /// Signals the watch engine and upload worker to stop but does NOT wait
+    /// for in-flight uploads. Calls `std::process::exit(0)` so the user sees
+    /// the tray disappear instantly instead of the 3s wait pipeline.stop()
+    /// would impose. In-flight `"uploading"` queue rows are recovered by
+    /// `reset_stale_uploading` on next launch — partial uploads will be
+    /// retried, no data is lost.
+    fn shutdown_and_exit(&mut self) -> ! {
+        info!("Immediate exit requested ... dropping in-flight work");
+
+        if let Some(ref mut engine) = self.watch_engine {
+            engine.stop_all();
+        }
+
+        if let Some(pipeline) = self.pipeline.take() {
+            pipeline.signal_stop();
+        }
+
+        // Skip destructors. The single-instance mutex, SQLite handles, and
+        // HTTP sockets are all reaped cleanly by the OS on process exit.
+        // SQLite's WAL mode + the queue's reset_stale_uploading on next
+        // launch make this safe.
+        std::process::exit(0);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,15 @@ fn main() -> anyhow::Result<()> {
         std::env::args().collect::<Vec<_>>()
     ));
 
+    // ── Legacy install cleanup ───────────────────────────────────────────
+    // 0.1.x → 0.2.0+ leftover detection. If a binary exists at a legacy path
+    // (%APPDATA%\ImmichSync\ or %APPDATA%\bees-roadhouse\immichsync\), kill
+    // any process running from it, remove the binary, and clear stale
+    // autostart / Apps & Features entries that point at the old location.
+    // Must run BEFORE migrate_to_split_layout so the migration doesn't fight
+    // a still-running v0.1.x for the state.db lock.
+    platform::cleanup_legacy_install();
+
     // ── Legacy data migration ────────────────────────────────────────────
     // Two-step migration covers every install we've shipped:
     //  1. Very-old %APPDATA%\ImmichSync\ (pre-namespace) → roaming config +

--- a/src/platform/install.rs
+++ b/src/platform/install.rs
@@ -573,6 +573,321 @@ pub fn delete_uninstall_registry() -> Result<(), InstallError> {
     }
 }
 
+// ── Legacy install cleanup (0.1.x → 0.2.0+ upgrade) ─────────────────────────
+
+/// Directories where 0.1.x binaries lived. Used to detect leftover installs
+/// when 0.2.x starts up for the first time after a manual download upgrade.
+///
+/// Returned in descending order of "newer" so callers that want to act on the
+/// most recent leftover first can do so without re-sorting.
+pub fn legacy_install_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(base) = dirs::config_dir() {
+        // 0.1.x with bees-roadhouse namespace (later builds).
+        dirs.push(base.join("bees-roadhouse").join("immichsync"));
+        // Pre-namespace original layout (earliest builds).
+        dirs.push(base.join("ImmichSync"));
+    }
+    dirs
+}
+
+/// Returns the subset of legacy install dirs that currently contain a binary.
+pub fn detect_legacy_installs() -> Vec<PathBuf> {
+    legacy_install_dirs()
+        .into_iter()
+        .filter(|d| d.join("immichsync.exe").exists())
+        .collect()
+}
+
+/// Returns true if `candidate` lives under (or equals) any of `legacy_dirs`.
+///
+/// Pure function ... no filesystem access, exact-string normalization only.
+/// Both inputs are compared in lowercase to handle Windows' case-insensitive
+/// paths. Symlinks are not resolved (best effort).
+pub fn path_is_under_legacy(candidate: &std::path::Path, legacy_dirs: &[PathBuf]) -> bool {
+    let candidate_norm = candidate.to_string_lossy().to_lowercase();
+    legacy_dirs.iter().any(|d| {
+        let prefix = d.to_string_lossy().to_lowercase();
+        candidate_norm == prefix || candidate_norm.starts_with(&format!("{prefix}\\"))
+    })
+}
+
+/// Detect and clean up leftovers from any pre-0.2.0 install.
+///
+/// 0.1.x binaries live at one of two paths:
+/// - `%APPDATA%\ImmichSync\immichsync.exe` (pre-namespace)
+/// - `%APPDATA%\bees-roadhouse\immichsync\immichsync.exe` (later 0.1.x)
+///
+/// 0.2.0 moved the binary to `%LOCALAPPDATA%\Programs\immichsync\` but the
+/// in-app update path only triggers cleanup when a binary already exists at
+/// the new path. Manual upgrades via Releases download don't go through that
+/// path, leaving:
+/// - The old binary on disk.
+/// - A stale HKCU\...\Run\ImmichSync autostart entry pointing at it.
+/// - A stale Apps & Features Uninstall key with InstallLocation at the old dir.
+/// - Worst case: the old binary still running, holding `state.db` open while
+///   `migrate_to_split_layout` tries to move it.
+///
+/// This function is called from `main()` before the migrations run so file
+/// locks are released first.
+pub fn cleanup_legacy_install() {
+    let legacy_dirs = legacy_install_dirs();
+    let active = detect_legacy_installs();
+    if active.is_empty() {
+        debug!("No legacy install detected");
+        return;
+    }
+
+    info!(
+        count = active.len(),
+        "Legacy install detected, cleaning up before migration"
+    );
+
+    // Kill any other immichsync.exe processes so file locks release. The PID
+    // filter excludes ourselves; we don't care which path the other instances
+    // are running from ... by definition they're either v0.1.x at a legacy
+    // path (the case we're handling) or a stale v0.2.x that should also exit
+    // before we install/migrate.
+    kill_other_immichsync_processes();
+
+    // Brief wait for kernel to flush handles. taskkill returns when the
+    // process exit signal has been delivered, but locked files can linger
+    // a few hundred ms after exit on Windows.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // Remove the binaries (and version.txt) so they can't auto-launch later.
+    for dir in &active {
+        let binary = dir.join("immichsync.exe");
+        if let Err(e) = std::fs::remove_file(&binary) {
+            warn!(path = %binary.display(), error = %e, "Failed to remove legacy binary");
+        } else {
+            info!(path = %binary.display(), "Removed legacy binary");
+        }
+        let version_file = dir.join("version.txt");
+        if version_file.exists() {
+            let _ = std::fs::remove_file(&version_file);
+        }
+    }
+
+    // Stale autostart / uninstall registry entries.
+    cleanup_stale_autostart(&legacy_dirs);
+    cleanup_stale_uninstall_key(&legacy_dirs);
+}
+
+/// Kill all immichsync.exe processes except ourselves.
+///
+/// Uses the same taskkill /FI "PID ne …" pattern as the install-update flow.
+/// Best-effort: failures (including "no tasks running" when there are none)
+/// are logged and ignored.
+fn kill_other_immichsync_processes() {
+    let our_pid = std::process::id();
+    let pid_filter = format!("PID ne {our_pid}");
+    match std::process::Command::new("taskkill")
+        .args(["/F", "/FI", &pid_filter, "/IM", "immichsync.exe"])
+        .output()
+    {
+        Ok(out) => {
+            debug!(
+                our_pid,
+                stdout = %String::from_utf8_lossy(&out.stdout).trim(),
+                stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                "Killed other immichsync.exe processes"
+            );
+        }
+        Err(e) => warn!(error = %e, "taskkill spawn failed"),
+    }
+}
+
+/// If the HKCU Run\ImmichSync value points at a legacy path, remove it.
+///
+/// We don't touch entries that point at the new install dir or anywhere else
+/// the user may have set up. Only legacy paths get cleared, so users who had
+/// autostart disabled stay disabled.
+fn cleanup_stale_autostart(legacy_dirs: &[PathBuf]) {
+    let Some(current) = read_autostart_value() else {
+        debug!("No autostart Run entry present");
+        return;
+    };
+    let path = std::path::Path::new(&current);
+    if !path_is_under_legacy(path, legacy_dirs) {
+        debug!(path = %current, "Autostart entry not in legacy path, leaving in place");
+        return;
+    }
+    info!(path = %current, "Removing stale autostart entry pointing at legacy path");
+    if let Err(e) = crate::platform::autostart::set_autostart(false) {
+        warn!(error = %e, "Failed to clear stale autostart entry");
+    }
+}
+
+/// If the Apps & Features Uninstall key's InstallLocation is a legacy dir,
+/// remove the whole subtree.
+fn cleanup_stale_uninstall_key(legacy_dirs: &[PathBuf]) {
+    let Some(install_location) = read_uninstall_install_location() else {
+        debug!("No Apps & Features Uninstall key present");
+        return;
+    };
+    let path = std::path::Path::new(&install_location);
+    if !path_is_under_legacy(path, legacy_dirs) {
+        debug!(
+            path = %install_location,
+            "Uninstall key InstallLocation not in legacy path, leaving in place"
+        );
+        return;
+    }
+    info!(
+        path = %install_location,
+        "Removing stale Apps & Features Uninstall key pointing at legacy path"
+    );
+    if let Err(e) = delete_uninstall_registry() {
+        warn!(error = %e, "Failed to clear stale Uninstall registry key");
+    }
+}
+
+/// Read the current `HKCU\Software\Microsoft\Windows\CurrentVersion\Run\ImmichSync`
+/// value as a UTF-8 string. Returns `None` if the key/value doesn't exist or
+/// the read fails for any other reason.
+fn read_autostart_value() -> Option<String> {
+    use windows::core::PCWSTR;
+    use windows::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_CURRENT_USER, KEY_READ,
+    };
+
+    const RUN_KEY: &str = "Software\\Microsoft\\Windows\\CurrentVersion\\Run\0";
+    const VALUE_NAME: &str = "ImmichSync\0";
+
+    let key_wide: Vec<u16> = RUN_KEY.encode_utf16().collect();
+    let value_wide: Vec<u16> = VALUE_NAME.encode_utf16().collect();
+
+    let mut hkey = HKEY::default();
+    if unsafe {
+        RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            PCWSTR(key_wide.as_ptr()),
+            0,
+            KEY_READ,
+            &mut hkey,
+        )
+    }
+    .is_err()
+    {
+        return None;
+    }
+
+    let mut byte_len: u32 = 0;
+    let probe = unsafe {
+        RegQueryValueExW(
+            hkey,
+            PCWSTR(value_wide.as_ptr()),
+            None,
+            None,
+            None,
+            Some(&mut byte_len),
+        )
+    };
+    if probe.is_err() || byte_len == 0 {
+        let _ = unsafe { RegCloseKey(hkey) };
+        return None;
+    }
+
+    let mut buf = vec![0u8; byte_len as usize];
+    let r = unsafe {
+        RegQueryValueExW(
+            hkey,
+            PCWSTR(value_wide.as_ptr()),
+            None,
+            None,
+            Some(buf.as_mut_ptr()),
+            Some(&mut byte_len),
+        )
+    };
+    let _ = unsafe { RegCloseKey(hkey) };
+    if r.is_err() {
+        return None;
+    }
+
+    decode_utf16_reg_sz(&buf)
+}
+
+/// Read `HKCU\...\Uninstall\ImmichSync\InstallLocation`. Returns `None` on
+/// missing key, missing value, or any decode failure.
+fn read_uninstall_install_location() -> Option<String> {
+    use windows::core::PCWSTR;
+    use windows::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_CURRENT_USER, KEY_READ,
+    };
+
+    let subkey_wide: Vec<u16> = UNINSTALL_SUBKEY
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
+    let value_wide: Vec<u16> = "InstallLocation\0".encode_utf16().collect();
+
+    let mut hkey = HKEY::default();
+    if unsafe {
+        RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            PCWSTR(subkey_wide.as_ptr()),
+            0,
+            KEY_READ,
+            &mut hkey,
+        )
+    }
+    .is_err()
+    {
+        return None;
+    }
+
+    let mut byte_len: u32 = 0;
+    let probe = unsafe {
+        RegQueryValueExW(
+            hkey,
+            PCWSTR(value_wide.as_ptr()),
+            None,
+            None,
+            None,
+            Some(&mut byte_len),
+        )
+    };
+    if probe.is_err() || byte_len == 0 {
+        let _ = unsafe { RegCloseKey(hkey) };
+        return None;
+    }
+
+    let mut buf = vec![0u8; byte_len as usize];
+    let r = unsafe {
+        RegQueryValueExW(
+            hkey,
+            PCWSTR(value_wide.as_ptr()),
+            None,
+            None,
+            Some(buf.as_mut_ptr()),
+            Some(&mut byte_len),
+        )
+    };
+    let _ = unsafe { RegCloseKey(hkey) };
+    if r.is_err() {
+        return None;
+    }
+
+    decode_utf16_reg_sz(&buf)
+}
+
+/// Decode a REG_SZ payload (UTF-16 LE, null-terminated, byte buffer) into
+/// a Rust String. Strips the trailing null. Returns None on length mismatch
+/// or invalid UTF-16.
+fn decode_utf16_reg_sz(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 2 || !bytes.len().is_multiple_of(2) {
+        return None;
+    }
+    let words: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    // Strip trailing nulls.
+    let end = words.iter().position(|&w| w == 0).unwrap_or(words.len());
+    String::from_utf16(&words[..end]).ok()
+}
+
 /// Relaunch from the installed exe path, forwarding all command-line arguments.
 ///
 /// On success this function does **not** return — the current process exits.
@@ -829,6 +1144,104 @@ mod tests {
         assert_eq!(
             UNINSTALL_SUBKEY,
             "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ImmichSync"
+        );
+    }
+
+    #[test]
+    fn path_is_under_legacy_matches_exact_and_descendants() {
+        let legacy = vec![
+            PathBuf::from("C:\\Users\\u\\AppData\\Roaming\\ImmichSync"),
+            PathBuf::from("C:\\Users\\u\\AppData\\Roaming\\bees-roadhouse\\immichsync"),
+        ];
+
+        // Exact match.
+        assert!(path_is_under_legacy(
+            std::path::Path::new("C:\\Users\\u\\AppData\\Roaming\\ImmichSync"),
+            &legacy
+        ));
+
+        // Descendant.
+        assert!(path_is_under_legacy(
+            std::path::Path::new("C:\\Users\\u\\AppData\\Roaming\\ImmichSync\\immichsync.exe"),
+            &legacy
+        ));
+        assert!(path_is_under_legacy(
+            std::path::Path::new(
+                "C:\\Users\\u\\AppData\\Roaming\\bees-roadhouse\\immichsync\\state.db"
+            ),
+            &legacy
+        ));
+
+        // Case-insensitive (Windows).
+        assert!(path_is_under_legacy(
+            std::path::Path::new("c:\\users\\U\\appdata\\roaming\\immichsync\\immichsync.exe"),
+            &legacy
+        ));
+
+        // New install location ... must NOT match.
+        assert!(!path_is_under_legacy(
+            std::path::Path::new(
+                "C:\\Users\\u\\AppData\\Local\\Programs\\immichsync\\immichsync.exe"
+            ),
+            &legacy
+        ));
+
+        // Sibling dir that shares a prefix string ... must NOT match (the
+        // backslash separator on the prefix guards against this).
+        assert!(!path_is_under_legacy(
+            std::path::Path::new("C:\\Users\\u\\AppData\\Roaming\\ImmichSyncBackup\\file.dat"),
+            &legacy
+        ));
+    }
+
+    #[test]
+    fn decode_utf16_reg_sz_handles_typical_values() {
+        // Encode "C:\\app" as UTF-16 LE + null terminator.
+        let s = "C:\\app";
+        let mut bytes: Vec<u8> = s.encode_utf16().flat_map(|w| w.to_le_bytes()).collect();
+        bytes.extend_from_slice(&[0, 0]); // null terminator
+        assert_eq!(decode_utf16_reg_sz(&bytes).as_deref(), Some(s));
+    }
+
+    #[test]
+    fn decode_utf16_reg_sz_strips_trailing_nulls() {
+        // "x" + two null words.
+        let bytes: Vec<u8> = "x"
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .chain(std::iter::once(0))
+            .flat_map(|w| w.to_le_bytes())
+            .collect();
+        assert_eq!(decode_utf16_reg_sz(&bytes).as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn decode_utf16_reg_sz_rejects_odd_length() {
+        assert_eq!(decode_utf16_reg_sz(&[1, 2, 3]), None);
+        assert_eq!(decode_utf16_reg_sz(&[1]), None);
+        assert_eq!(decode_utf16_reg_sz(&[]), None);
+    }
+
+    #[test]
+    fn legacy_install_dirs_contains_both_known_layouts() {
+        let dirs = legacy_install_dirs();
+        // We can't assert the absolute path (depends on the runtime user),
+        // but we can assert each leaf matches the expected layout.
+        let names: Vec<String> = dirs
+            .iter()
+            .map(|d| d.display().to_string().to_lowercase())
+            .collect();
+        assert!(
+            names
+                .iter()
+                .any(|n| n.ends_with("\\immichsync") && !n.contains("bees-roadhouse")),
+            "Expected pre-namespace dir ending in \\ImmichSync, got: {names:?}"
+        );
+        assert!(
+            names
+                .iter()
+                .any(|n| n.ends_with("\\bees-roadhouse\\immichsync")),
+            "Expected mixed-roaming dir ending in \\bees-roadhouse\\immichsync, got: {names:?}"
         );
     }
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -25,8 +25,8 @@ pub const APP_USER_MODEL_ID: &str = "BeesRoadhouse.ImmichSync";
 
 pub use autostart::set_autostart;
 pub use install::{
-    install_exe, installed_exe_path, is_running_installed, migrate_legacy_data,
-    migrate_to_split_layout, relaunch_installed,
+    cleanup_legacy_install, install_exe, installed_exe_path, is_running_installed,
+    migrate_legacy_data, migrate_to_split_layout, relaunch_installed,
 };
 pub use shortcuts::{create_desktop_shortcut, create_start_menu_shortcut};
 pub use single_instance::SingleInstance;

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -159,6 +159,17 @@ impl UploadPipeline {
         self.queue.get_stats().map_err(anyhow::Error::from)
     }
 
+    /// Signal the worker loop to stop without waiting for in-flight uploads.
+    ///
+    /// Used by the user-initiated Quit path: drop whatever is running, exit
+    /// fast. In-flight `"uploading"` rows are reset to `"pending"` by
+    /// `reset_stale_uploading` on the next launch, so nothing is lost ...
+    /// just retried.
+    pub fn signal_stop(&self) {
+        info!("Signalling upload pipeline to stop (no wait)");
+        self.worker.stop();
+    }
+
     /// Signal the worker loop to stop and wait for it to finish.
     ///
     /// After calling `stop()`, the pipeline should not be used again.

--- a/src/upload/queue.rs
+++ b/src/upload/queue.rs
@@ -212,6 +212,21 @@ impl UploadQueue {
         let file_size_i64 = file_size_u64 as i64;
         let file_mtime = mtime_secs(&meta);
 
+        // Placeholder re-check: the watcher's filter dropped cloud-placeholder
+        // files at discovery time, but a file can be evicted to the cloud
+        // *between* discovery and now (OneDrive/SeaDrive auto-evict under
+        // storage pressure, or a user manually toggles "free up space"). If
+        // we hash a placeholder, the read triggers a full cloud download
+        // ... gigabytes of bandwidth and CPU for a file we're just going
+        // to skip on the next watcher pass anyway.
+        if crate::watch::filter::is_online_file(&meta) {
+            info!(
+                path = %path_str,
+                "Skipping file that became a cloud placeholder after watcher discovery"
+            );
+            return Ok(None);
+        }
+
         // 1. Fast-path dedup ... canonicalise the path so the lookup matches
         // the form `record_upload` stored (no `\\?\` prefix). Free win when
         // the file's been uploaded before with the same size + mtime.
@@ -230,11 +245,8 @@ impl UploadQueue {
             return Ok(None);
         }
 
-        // 2. SHA-1 hash + content dedup. Reading the file here will trigger
-        // a cloud download for placeholder files ... which is fine because
-        // the watcher's filter already dropped placeholders by default, and
-        // any placeholder that reached here has either been already-materialised
-        // or the user explicitly opted in to uploading placeholders.
+        // 2. SHA-1 hash + content dedup. Safe to read at this point ... the
+        // placeholder re-check above already covered the watcher/queue race.
         let hash = hasher::hash_file(&path).map_err(|source| QueueError::Hash {
             path: path_str.clone(),
             source,
@@ -461,5 +473,45 @@ mod tests {
         let queue = UploadQueue::new(store, 2);
         let result = queue.process_file(PathBuf::from("/nonexistent/photo.jpg"), None);
         assert!(result.is_err());
+    }
+
+    /// Mark a file with FILE_ATTRIBUTE_OFFLINE so the placeholder re-check
+    /// sees it as a cloud placeholder. Mirror of the helper in filter::tests.
+    #[cfg(windows)]
+    fn mark_offline(path: &std::path::Path) -> bool {
+        use std::os::windows::ffi::OsStrExt;
+        let wide: Vec<u16> = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        unsafe {
+            let current = windows::Win32::Storage::FileSystem::GetFileAttributesW(
+                windows::core::PCWSTR(wide.as_ptr()),
+            );
+            let combined = current | crate::watch::filter::FILE_ATTRIBUTE_OFFLINE;
+            windows::Win32::Storage::FileSystem::SetFileAttributesW(
+                windows::core::PCWSTR(wide.as_ptr()),
+                windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES(combined),
+            )
+            .is_ok()
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn process_file_skips_cloud_placeholder() {
+        let store = Arc::new(MockStore::default());
+        let queue = UploadQueue::new(store.clone(), 2);
+        let tmp = make_temp_file();
+        assert!(mark_offline(tmp.path()), "Failed to mark file offline");
+
+        // Should be skipped (return Ok(None)) without hashing the file or
+        // enqueueing — that's the whole point of the re-check.
+        let id = queue.process_file(tmp.path().to_path_buf(), None).unwrap();
+        assert!(id.is_none(), "Placeholder file should not enqueue");
+
+        let stats = queue.get_stats().unwrap();
+        assert_eq!(stats.total, 0, "Placeholder must not produce a queue row");
     }
 }

--- a/src/upload/worker.rs
+++ b/src/upload/worker.rs
@@ -298,6 +298,31 @@ async fn process_item(
         "Processing upload queue entry"
     );
 
+    // Placeholder re-check: the file may have been evicted to the cloud
+    // between enqueue and now (OneDrive / SeaDrive can auto-evict under
+    // storage pressure). Opening the file for upload would trigger a full
+    // cloud hydration ... gigabytes of bandwidth + CPU for a file the
+    // watcher will re-skip on its next pass anyway. Mark the entry failed
+    // with a recognisable marker; the watcher's reconciliation loop will
+    // re-enqueue it once the file is local again.
+    if let Ok(meta) = std::fs::metadata(&path) {
+        if crate::watch::filter::is_online_file(&meta) {
+            info!(
+                id = entry.id,
+                path = %entry.file_path,
+                "File became cloud placeholder; deferring upload until it's local again"
+            );
+            if let Err(e) = store.update_status(
+                entry.id,
+                "failed",
+                Some("file became a cloud placeholder; will re-enqueue when local"),
+            ) {
+                error!(id = entry.id, error = %e, "Failed to mark deferred entry");
+            }
+            return;
+        }
+    }
+
     // Mark as uploading.
     if let Err(e) = store.update_status(entry.id, "uploading", None) {
         error!(id = entry.id, error = %e, "Failed to mark entry as uploading");


### PR DESCRIPTION
## Summary

Promotes v0.2.1 from development to release. Single bug-fix commit (#47).

### Contents
- **Upgrade cleanup**: detect + remove leftover 0.1.x binary, autostart entry, and Apps & Features key before migrations run, so a manual upgrade across the 0.2.0 install-layout change doesn't deadlock on a locked state.db or leave orphaned registry entries.
- **Online-file races**: re-check cloud-placeholder attributes in queue.process_file and worker.process_item, closing the watcher → queue and queue → worker race windows where a file evicted to the cloud would hydrate gigabytes for a hash/upload that gets discarded anyway.
- **Instant exit**: tray Quit and WM_QUIT now process::exit(0) after signaling the workers, instead of waiting up to 3s on graceful pipeline shutdown.

## Test plan
- [x] CI green on this PR (build + artifact regen)
- [x] Merge with **merge commit** (ruleset enforces — squash is not on the menu)
- [x] Release workflow publishes v0.2.1 binary to GitHub Releases
- [x] Manual install over a v0.1.8 / v0.2.0 install ... verify the legacy binary and stale Run entry are gone after first launch