### PR TITLE
fix: wire upload timeout_secs to HTTP read_timeout (fixes 499 on 50GB+ uploads)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -57,15 +57,25 @@ impl ImmichClient {
     /// `base_url` should be the server root without a trailing slash, e.g.
     /// `"https://photos.example.com"`. The `x-api-key` header is set as a
     /// default so every request inherits it automatically.
+    ///
+    /// Uses a 3600s inactivity (read) timeout; pass a timeout via
+    /// [`with_bandwidth_limit`] if you need a different value.
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Result<Self, ApiError> {
-        Self::with_bandwidth_limit(base_url, api_key, 0)
+        Self::with_bandwidth_limit(base_url, api_key, 0, 3600)
     }
 
-    /// Create a new client with an optional bandwidth limit (in KB/s, 0 = unlimited).
+    /// Create a new client with an optional bandwidth limit (in KB/s, 0 = unlimited)
+    /// and a configurable per-request inactivity timeout (in seconds).
+    ///
+    /// `timeout_secs` is the HTTP read (inactivity) timeout: how long to wait
+    /// with no response bytes before aborting. Size it for the slowest backend
+    /// you expect — a 50GB upload to an Orange Pi can take several minutes of
+    /// post-upload server processing before the first response byte arrives.
     pub fn with_bandwidth_limit(
         base_url: impl Into<String>,
         api_key: impl Into<String>,
         bandwidth_limit_kbps: u64,
+        timeout_secs: u64,
     ) -> Result<Self, ApiError> {
         let api_key = api_key.into();
         let base_url = base_url.into().trim_end_matches('/').to_string();
@@ -79,17 +89,23 @@ impl ImmichClient {
 
         // Timeouts/keep-alive tuned for streaming uploads of large files (50GB+ videos):
         // - No overall .timeout() — a 50GB upload at 10MB/s legitimately takes ~83 minutes.
-        // - read_timeout: 120s without any bytes flowing = dead connection, abort fast.
+        //   An overall request timeout would kill a healthy long-running transfer, so we
+        //   deliberately omit it. Only inactivity (read_timeout) is bounded.
+        // - read_timeout: configurable inactivity timeout (default 3600s). This is NOT a
+        //   transfer-duration limit — it fires only when NO response bytes arrive for this
+        //   long. A slow backend (Orange Pi / Rockchip SBC) can take many minutes checksumming
+        //   a 50GB file after the last upload byte is sent; the read_timeout must outlast that
+        //   post-upload processing window. 1 hour of silence = give up.
         // - connect_timeout: 30s to establish TCP+TLS is plenty on any non-pathological link.
         // - tcp_keepalive: 60s probes keep middleboxes (firewalls, NATs) from idle-closing
         //   the connection during long uploads. Without this, a quiet TCP stream is silently
-        //   reaped by a firewall and read_timeout takes the full 120s to notice.
+        //   reaped by a firewall and read_timeout takes the full timeout duration to notice.
         // - pool_idle_timeout: 120s caps how long an idle connection stays in the pool
         //   before a fresh one is opened on next use.
         let client = reqwest::Client::builder()
             .default_headers(default_headers)
             .connect_timeout(Duration::from_secs(30))
-            .read_timeout(Duration::from_secs(120))
+            .read_timeout(Duration::from_secs(timeout_secs))
             .tcp_keepalive(Duration::from_secs(60))
             .pool_idle_timeout(Duration::from_secs(120))
             .build()

--- a/src/app.rs
+++ b/src/app.rs
@@ -526,9 +526,15 @@ impl App {
         if server_changed {
             info!("Server config changed, recreating client");
 
-            // Recreate the Immich client.
+            // Recreate the Immich client with the full upload config (bandwidth
+            // limit and inactivity timeout may have changed along with the server).
             if !self.config.server.url.is_empty() && !self.config.server.api_key.is_empty() {
-                match ImmichClient::new(&self.config.server.url, &self.config.server.api_key) {
+                match ImmichClient::with_bandwidth_limit(
+                    &self.config.server.url,
+                    &self.config.server.api_key,
+                    self.config.upload.bandwidth_limit_kbps,
+                    self.config.upload.timeout_secs,
+                ) {
                     Ok(c) => {
                         self.client = Some(c);
                         if let Some(ref mut tray) = self.tray {

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,7 +123,14 @@ pub struct UploadConfig {
     /// Maximum number of retry attempts before a queue entry is marked failed.
     pub max_retries: u32,
 
-    /// Per-request HTTP timeout in seconds.
+    /// Per-request inactivity (HTTP read) timeout in seconds.
+    ///
+    /// This is the maximum time to wait with no response bytes before aborting
+    /// a request. It is NOT an overall transfer-duration limit — a 50GB upload
+    /// at 10MB/s legitimately streams for ~83 minutes without triggering it.
+    /// The timeout fires only when the server stops sending bytes entirely,
+    /// e.g. during post-upload checksumming on a slow backend (Orange Pi /
+    /// Rockchip SBC). Default 3600s (1 hour) accommodates those cases.
     pub timeout_secs: u64,
 
     /// Number of days to retain files in `.immichsync-trash/` before
@@ -139,7 +146,7 @@ impl Default for UploadConfig {
             bandwidth_limit_kbps: 0,
             order: "newest_first".to_string(),
             max_retries: 5,
-            timeout_secs: 300,
+            timeout_secs: 3600,
             trash_retention_days: 14,
         }
     }
@@ -432,7 +439,7 @@ mod tests {
         assert_eq!(cfg.upload.bandwidth_limit_kbps, 0);
         assert_eq!(cfg.upload.order, "newest_first");
         assert_eq!(cfg.upload.max_retries, 5);
-        assert_eq!(cfg.upload.timeout_secs, 300);
+        assert_eq!(cfg.upload.timeout_secs, 3600);
         assert!(cfg.devices.auto_watch);
         assert!(cfg.devices.look_for_dcim);
         assert_eq!(cfg.devices.on_insert, "auto");

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,7 @@ fn main() -> anyhow::Result<()> {
             &config.server.url,
             &config.server.api_key,
             config.upload.bandwidth_limit_kbps,
+            config.upload.timeout_secs,
         ) {
             Ok(c) => {
                 info!(url = %config.server.url, "Immich client created");


### PR DESCRIPTION
## Root cause

`ImmichClient::with_bandwidth_limit` hardcoded `.read_timeout(Duration::from_secs(120))` and never read the configured `UploadConfig.timeout_secs`. The `read_timeout` is an **inactivity** timeout -- it fires when no response bytes arrive for the configured duration. On a slow backend (Orange Pi / Rockchip SBC), Immich can spend several minutes checksumming a 50 GB file after receiving the last upload byte; no response bytes flow during that window. After 120 seconds of silence, reqwest fires the timeout and drops the connection -- the server sees a premature client close and returns HTTP 499. The `timeout_secs` config knob (intended to control this) was dead-wired: set in config, never passed to the client.

## Fix

- **`src/api/mod.rs`**: added `timeout_secs: u64` param to `with_bandwidth_limit`; `.read_timeout` now uses it instead of the hardcoded 120s. `ImmichClient::new` (connection-test path used by settings/first-run UI) defaults to 3600s. Updated the comment block to explain that this is an inactivity-only timeout, deliberately NOT an overall timeout (a healthy 50 GB transfer at 10 MB/s takes ~83 min; an overall timeout would kill it).
- **`src/main.rs`**: passes `config.upload.timeout_secs` to `with_bandwidth_limit` at app startup.
- **`src/app.rs`**: `apply_new_config` switched from `ImmichClient::new` to `with_bandwidth_limit`, so both bandwidth limit and inactivity timeout track the live config when server settings change.
- **`src/config.rs`**: `UploadConfig::default().timeout_secs` raised from 300 to 3600 (1 hour); doc comment updated to describe inactivity-only semantics and the slow-backend use case.

No overall `.timeout()` was added -- the existing design deliberately omits it and that is preserved.

Users can raise `timeout_secs` in settings if their server needs more than an hour to process a single file.

## Born-green gate

```
cargo test --locked         → test result: ok. 110 passed; 0 failed
cargo check --release --locked → Finished `release` profile
cargo clippy --all-targets -- -D warnings → Finished `dev` profile (zero warnings)
cargo fmt --all -- --check  → (clean, no output)
```

All four CI gates pass locally.