### PR TITLE
chore: bump version to 0.2.3 (upload-timeout fix release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "immichsync"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "immichsync"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Windows system tray app that syncs photos/videos to Immich"
 license = "GPL-3.0-only"


### PR DESCRIPTION
Version bump only. #53 (the upload timeout fix, fixes 499s on large uploads) merged to development without bumping the version, and 0.2.2 is already released. Bump 0.2.2 -> 0.2.3 so the dev->release push tags a fresh v0.2.3 and the release workflow ships the fixed Windows binary.

Follows the Change Lifecycle version-bump rule (retroactive for #53). Patch bump per the fix/ semver convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)