### PR TITLE
release: v0.2.3 — upload timeout fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "immichsync"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "immichsync"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Windows system tray app that syncs photos/videos to Immich"
 license = "GPL-3.0-only"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -57,15 +57,25 @@ impl ImmichClient {
     /// `base_url` should be the server root without a trailing slash, e.g.
     /// `"https://photos.example.com"`. The `x-api-key` header is set as a
     /// default so every request inherits it automatically.
+    ///
+    /// Uses a 3600s inactivity (read) timeout; pass a timeout via
+    /// [`with_bandwidth_limit`] if you need a different value.
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Result<Self, ApiError> {
-        Self::with_bandwidth_limit(base_url, api_key, 0)
+        Self::with_bandwidth_limit(base_url, api_key, 0, 3600)
     }
 
-    /// Create a new client with an optional bandwidth limit (in KB/s, 0 = unlimited).
+    /// Create a new client with an optional bandwidth limit (in KB/s, 0 = unlimited)
+    /// and a configurable per-request inactivity timeout (in seconds).
+    ///
+    /// `timeout_secs` is the HTTP read (inactivity) timeout: how long to wait
+    /// with no response bytes before aborting. Size it for the slowest backend
+    /// you expect — a 50GB upload to an Orange Pi can take several minutes of
+    /// post-upload server processing before the first response byte arrives.
     pub fn with_bandwidth_limit(
         base_url: impl Into<String>,
         api_key: impl Into<String>,
         bandwidth_limit_kbps: u64,
+        timeout_secs: u64,
     ) -> Result<Self, ApiError> {
         let api_key = api_key.into();
         let base_url = base_url.into().trim_end_matches('/').to_string();
@@ -79,17 +89,23 @@ impl ImmichClient {
 
         // Timeouts/keep-alive tuned for streaming uploads of large files (50GB+ videos):
         // - No overall .timeout() — a 50GB upload at 10MB/s legitimately takes ~83 minutes.
-        // - read_timeout: 120s without any bytes flowing = dead connection, abort fast.
+        //   An overall request timeout would kill a healthy long-running transfer, so we
+        //   deliberately omit it. Only inactivity (read_timeout) is bounded.
+        // - read_timeout: configurable inactivity timeout (default 3600s). This is NOT a
+        //   transfer-duration limit — it fires only when NO response bytes arrive for this
+        //   long. A slow backend (Orange Pi / Rockchip SBC) can take many minutes checksumming
+        //   a 50GB file after the last upload byte is sent; the read_timeout must outlast that
+        //   post-upload processing window. 1 hour of silence = give up.
         // - connect_timeout: 30s to establish TCP+TLS is plenty on any non-pathological link.
         // - tcp_keepalive: 60s probes keep middleboxes (firewalls, NATs) from idle-closing
         //   the connection during long uploads. Without this, a quiet TCP stream is silently
-        //   reaped by a firewall and read_timeout takes the full 120s to notice.
+        //   reaped by a firewall and read_timeout takes the full timeout duration to notice.
         // - pool_idle_timeout: 120s caps how long an idle connection stays in the pool
         //   before a fresh one is opened on next use.
         let client = reqwest::Client::builder()
             .default_headers(default_headers)
             .connect_timeout(Duration::from_secs(30))
-            .read_timeout(Duration::from_secs(120))
+            .read_timeout(Duration::from_secs(timeout_secs))
             .tcp_keepalive(Duration::from_secs(60))
             .pool_idle_timeout(Duration::from_secs(120))
             .build()

--- a/src/app.rs
+++ b/src/app.rs
@@ -542,9 +542,15 @@ impl App {
         if server_changed {
             info!("Server config changed, recreating client");
 
-            // Recreate the Immich client.
+            // Recreate the Immich client with the full upload config (bandwidth
+            // limit and inactivity timeout may have changed along with the server).
             if !self.config.server.url.is_empty() && !self.config.server.api_key.is_empty() {
-                match ImmichClient::new(&self.config.server.url, &self.config.server.api_key) {
+                match ImmichClient::with_bandwidth_limit(
+                    &self.config.server.url,
+                    &self.config.server.api_key,
+                    self.config.upload.bandwidth_limit_kbps,
+                    self.config.upload.timeout_secs,
+                ) {
                     Ok(c) => {
                         self.client = Some(c);
                         if let Some(ref mut tray) = self.tray {

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,7 +123,14 @@ pub struct UploadConfig {
     /// Maximum number of retry attempts before a queue entry is marked failed.
     pub max_retries: u32,
 
-    /// Per-request HTTP timeout in seconds.
+    /// Per-request inactivity (HTTP read) timeout in seconds.
+    ///
+    /// This is the maximum time to wait with no response bytes before aborting
+    /// a request. It is NOT an overall transfer-duration limit — a 50GB upload
+    /// at 10MB/s legitimately streams for ~83 minutes without triggering it.
+    /// The timeout fires only when the server stops sending bytes entirely,
+    /// e.g. during post-upload checksumming on a slow backend (Orange Pi /
+    /// Rockchip SBC). Default 3600s (1 hour) accommodates those cases.
     pub timeout_secs: u64,
 
     /// Number of days to retain files in `.immichsync-trash/` before
@@ -139,7 +146,7 @@ impl Default for UploadConfig {
             bandwidth_limit_kbps: 0,
             order: "newest_first".to_string(),
             max_retries: 5,
-            timeout_secs: 300,
+            timeout_secs: 3600,
             trash_retention_days: 14,
         }
     }
@@ -432,7 +439,7 @@ mod tests {
         assert_eq!(cfg.upload.bandwidth_limit_kbps, 0);
         assert_eq!(cfg.upload.order, "newest_first");
         assert_eq!(cfg.upload.max_retries, 5);
-        assert_eq!(cfg.upload.timeout_secs, 300);
+        assert_eq!(cfg.upload.timeout_secs, 3600);
         assert!(cfg.devices.auto_watch);
         assert!(cfg.devices.look_for_dcim);
         assert_eq!(cfg.devices.on_insert, "auto");

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,6 +299,7 @@ fn main() -> anyhow::Result<()> {
             &config.server.url,
             &config.server.api_key,
             config.upload.bandwidth_limit_kbps,
+            config.upload.timeout_secs,
         ) {
             Ok(c) => {
                 info!(url = %config.server.url, "Immich client created");


### PR DESCRIPTION
Cuts v0.2.3. Ships #53 (wire upload timeout_secs through to the HTTP read_timeout, default 3600s, inactivity-only) which fixes the HTTP 499 client-closed failures on large (50GB+) uploads to a slow Immich server, plus the apply_new_config bandwidth-limit drop the same PR caught. Version bumped 0.2.2 -> 0.2.3 in #54.

Merge-commit (not squash) per the branching standard so release ancestry holds. The push to release triggers release.yml -> tags v0.2.3, builds the Windows binary, publishes the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)